### PR TITLE
fix: display gender in Chinese for avatar list API

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -936,7 +936,7 @@ def get_avatar_list_simple():
             "name": a.name,
             "sect_name": sect_name,
             "realm": realm_str,
-            "gender": a.gender.value,
+            "gender": str(a.gender),
             "age": a.age.age
         })
     


### PR DESCRIPTION
## Summary

The `/api/meta/avatar_list` endpoint returns `a.gender.value` which gives English values (`"male"`/`"female"`), while other APIs like `get_structured_info()` use `str(a.gender)` which returns Chinese (`"男"`/`"女"`).

This causes inconsistent display in the delete avatar panel.

## Screenshot
<img width="2596" height="1454" alt="CleanShot 2026-01-04 at 00 08 17@2x" src="https://github.com/user-attachments/assets/3999cacf-619b-4cd8-914c-85022121afc6" />

<img width="2908" height="1520" alt="CleanShot 2026-01-04 at 00 57 49@2x" src="https://github.com/user-attachments/assets/056a291d-b1b0-4caa-a766-d1fd5fdff280" />