### PR TITLE
fix: correct master-apprentice relation direction in fortune event

### DIFF
--- a/src/classes/fortune.py
+++ b/src/classes/fortune.py
@@ -461,7 +461,8 @@ async def try_trigger_fortune(avatar: Avatar) -> list[Event]:
             # 找不到合适的师傅
             return []
         # 建立师徒关系：avatar 是徒弟，master 是师傅
-        avatar.set_relation(master, Relation.APPRENTICE)
+        # avatar 视 master 为 MASTER，master 视 avatar 为 APPRENTICE（自动设置对偶）。
+        avatar.set_relation(master, Relation.MASTER)
         res_text = f"{avatar.name} 拜 {master.name} 为师"
         related_avatars.append(master.id)
         actors_for_story = [avatar, master]  # 拜师奇遇需要两个人的信息


### PR DESCRIPTION
In the `find_master` fortune event, the relation was incorrectly set as `avatar.set_relation(master, APPRENTICE)`, meaning 'avatar considers master as apprentice'. Fixed to `avatar.set_relation(master, MASTER)` so that avatar (the apprentice) correctly considers master as their master.

<img width="1448" height="1604" alt="CleanShot 2026-01-04 at 01 38 37@2x" src="https://github.com/user-attachments/assets/a242f123-3fe4-4973-a70e-2a898b3de644" />
