### PR TITLE
fix: prevent actions on dead avatars

### DIFF
--- a/src/classes/action/targeting_mixin.py
+++ b/src/classes/action/targeting_mixin.py
@@ -57,4 +57,26 @@ class TargetingMixin:
         avatar.load_decide_result_chain([(action_name, params)], avatar.thinking, "")
         avatar.commit_next_plan()
 
+    def validate_target_avatar(self, name: str | None) -> tuple["Avatar | None", bool, str]:
+        """
+        验证目标角色是否有效（存在且存活）。
+
+        Args:
+            name: 目标角色名。
+
+        Returns:
+            (target, can_proceed, reason)
+            - target: 找到的角色对象，无效时为 None。
+            - can_proceed: 是否可以继续。
+            - reason: 失败原因（成功时为空字符串）。
+        """
+        if not name:
+            return None, False, "缺少目标参数"
+        target = self.find_avatar_by_name(name)
+        if target is None:
+            return None, False, "目标不存在"
+        if target.is_dead:
+            return None, False, "目标已死亡"
+        return target, True, ""
+
 

--- a/src/classes/mutual_action/mutual_action.py
+++ b/src/classes/mutual_action/mutual_action.py
@@ -140,6 +140,9 @@ class MutualAction(DefineAction, LLMAction, ActualActionMixin, TargetingMixin):
         """
         检查互动动作能否启动：目标需在发起者的交互范围内。
         子类通过实现 _can_start 来添加额外检查。
+
+        注意：此方法未使用 TargetingMixin.validate_target_avatar()，
+        因为需要额外检查 target == self.avatar 和调用子类的 _can_start()。
         """
         if target_avatar is None:
             return False, "缺少参数 target_avatar"
@@ -148,6 +151,8 @@ class MutualAction(DefineAction, LLMAction, ActualActionMixin, TargetingMixin):
             return False, "目标不存在"
         if target == self.avatar:
             return False, "不能对自己发起互动"
+        if target.is_dead:
+            return False, "目标已死亡"
         # 调用子类的额外检查
         return self._can_start(target)
 


### PR DESCRIPTION
## Summary

Previously, avatars could attempt actions on dead avatars (see screenshot below).

This PR adds unified dead avatar validation:
- Add `validate_target_avatar()` to `TargetingMixin` for unified target validation
- Update `Attack` and `Assassinate` to use the new validation method
- `MutualAction` keeps inline check (needs extra logic for self-targeting and subclass checks)
- Add tests for dead target validation

### Fixed actions
- `Attack`
- `Assassinate`
- All `MutualAction` subclasses (inherited from `MutualAction.can_start`):
  - Talk, Conversation, DriveAway, DualCultivation, GiftSpiritStone, Impart, Spar

### Not checked (semantically valid)
- `MoveAwayFromAvatar` - moving away from a corpse is valid
- `Escape` - if the attacker dies, the action naturally fails

<img width="1372" height="200" alt="CleanShot 2026-01-04 at 19 32 41@2x" src="https://github.com/user-attachments/assets/bc55bdff-a5ea-4167-ab31-86406cf2e479" />

## Test plan
- [x] Attack on dead target returns `(False, "目标已死亡")`
- [x] Assassinate on dead target returns `(False, "目标已死亡")`
- [x] Talk on dead target returns `(False, "目标已死亡")`
- [x] Talk on self returns `(False, "不能对自己发起互动")`