### PR TITLE
fix: handle null action_params from LLM response

### DIFF
--- a/src/classes/ai.py
+++ b/src/classes/ai.py
@@ -87,9 +87,10 @@ class LLMAI(AI):
             
             for p in raw_pairs:
                 if isinstance(p, list) and len(p) == 2:
-                    pairs.append((p[0], p[1]))
+                    # LLM 可能返回 null 作为 params，需要转为空字典。
+                    pairs.append((p[0], p[1] or {}))
                 elif isinstance(p, dict) and "action_name" in p and "action_params" in p:
-                    pairs.append((p["action_name"], p["action_params"]))
+                    pairs.append((p["action_name"], p["action_params"] or {}))
                 else:
                     continue
             

--- a/src/sim/simulator.py
+++ b/src/sim/simulator.py
@@ -126,6 +126,10 @@ class Simulator:
     async def _phase_execute_actions(self):
         """
         执行阶段：推进当前动作，支持同月链式抢占即时结算，返回期间产生的事件。
+
+        TODO: 为单个角色的 tick_action() 添加 try-except 处理。
+              当前如果任一角色的动作执行抛出异常，整个 step() 会失败，
+              导致 month_stamp 不会推进，游戏卡在同一个月份无限循环。
         """
         events = []
         MAX_LOCAL_ROUNDS = 3

--- a/static/templates/ai.txt
+++ b/static/templates/ai.txt
@@ -14,7 +14,7 @@
         "avatar_thinking": ... // 从角色角度，以第一人称视角，简单清晰的描述想法
         "current_emotion": ... // 从以下列表中选择一个最符合当前心情的词：平静、开心、愤怒、悲伤、恐惧、惊讶、期待、厌恶、疑惑、疲惫
         "short_term_objective": ..., // 角色接下来一段时间的短期目标
-        "action_name_params_pairs": list[Tuple[action_name, action_params]]  // 一次性决定未来的5~10个动作，按顺序执行
+        "action_name_params_pairs": list[Tuple[action_name, action_params]]  // 一次性决定未来的5~10个动作，按顺序执行。action_params 必须是字典 {}，不能是 null。
     }}
 }}
 


### PR DESCRIPTION
## Summary
- LLM sometimes returns `null` instead of `{}` for `action_params` when an action doesn't require parameters (e.g., `["Cultivate", null]`)
- This caused `AttributeError: 'NoneType' object has no attribute 'items'` when calling `.items()` on `None`

See the log below for the `["Cultivate", null]` part:
```log
2026-01-05 00:28:00 - INFO - LLM_RESPONSE:
```json
{
    "顾如玉": {
        "avatar_thinking": "我是顾如玉，元婴后期的冰灵根修士。当前正处于【水德之纪】的修炼加成期，这是闭关苦修的大好时机。我的长期目标是突破化神境、炼成冰魄神鞭、寻得道侣共修。短期来看，我刚刚在沧澜城出售了材料，情绪有些疲惫，但灵石充裕（41317灵石）。我的冰灵根（金、水）与玄水秘境（水行灵气10）高度匹配，且距离只有2个月路程。考虑到当前天地灵机对水行修炼的加成，我应该尽快返回玄水秘境继续修炼，提升修为，为突破化神做准备。同时，我的朋友钟安魂也在附近（元婴前期），我可以先与她交流一下，了解她的近况，或许能获得一些有用的信息或材料。",
        "current_emotion": "疲惫",
        "short_term_objective": "利用【水德之纪】的修炼加成，返回玄水秘境继续闭关修炼，提升修为，为突破化神做准备。同时与朋友钟安魂交流，了解彼此近况。",
        "action_name_params_pairs": [
            ["MoveToAvatar", {"avatar_name": "钟安魂"}],
            ["Conversation", {"target_avatar": "钟安魂"}],
            ["MoveToRegion", {"region": "玄水秘境"}],
            ["Cultivate", null],
            ["Cultivate", null],
            ["Cultivate", null],
            ["Cultivate", null],
            ["Cultivate", null]
        ]
    }
}
```

<img width="848" height="554" alt="CleanShot 2026-01-05 at 01 29 00@2x" src="https://github.com/user-attachments/assets/1eee215c-c500-4c88-ab9f-7d15b1260f0d" />


## Changes
- Add defensive check in `ai.py` to convert `null` to `{}`
- Update prompt template to explicitly require `{}` instead of `null`

## Root Cause
The prompt template specified:
```
"action_name_params_pairs": list[Tuple[action_name, action_params]]
```
But didn't specify that `action_params` must be `{}` when empty, not `null`. LLM interpreted "no params" as `null`.

## Test Plan
- [x] Restart server and verify no more `'NoneType' object has no attribute 'items'` errors
- [x] Verify LLM returns `{}` instead of `null` for parameterless actions