### PR TITLE
feat: add GitHub Actions CI for pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -v


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically run pytest on PRs and pushes to main
- Uses Python 3.11 with pip caching for faster runs

## Test plan
- [ ] Merge this PR and verify workflow runs on subsequent PRs