### PR TITLE
refactor: remove region_names dict, use regions traversal instead

### DIFF
--- a/src/classes/map.py
+++ b/src/classes/map.py
@@ -20,18 +20,14 @@ class Map():
         self.region_cors: dict[int, list[tuple[int, int]]] = {}
         
         # 区域字典，由外部加载器 (load_map.py) 填充
+        # 只维护 regions[id] 作为唯一的 source of truth，按名称查找通过遍历实现
         self.regions = {}
-        self.region_names = {}
         self.sect_regions = {}
         
-        # 这些分类字典可能暂时不再自动维护，或者需要 load_map.py 手动维护
-        # 为了兼容性，先初始化为空
+        # 分类字典（暂未使用，保留以备兼容）
         self.normal_regions = {}
-        self.normal_region_names = {}
         self.cultivate_regions = {}
-        self.cultivate_region_names = {}
         self.city_regions = {}
-        self.city_region_names = {}
 
     def update_sect_regions(self) -> None:
         """根据当前 self.regions 动态刷新宗门总部区域字典。"""

--- a/src/run/load_map.py
+++ b/src/run/load_map.py
@@ -132,7 +132,6 @@ def _load_and_assign_regions(game_map: Map, region_coords: dict[int, list[tuple[
             try:
                 region_obj = cls(**params)
                 game_map.regions[rid] = region_obj
-                game_map.region_names[region_obj.name] = region_obj
                 
                 # 写入 Map 缓存 (region_cors)
                 game_map.region_cors[rid] = cors

--- a/tests/test_normalize_resolution.py
+++ b/tests/test_normalize_resolution.py
@@ -52,7 +52,7 @@ def test_normalize_weapon_type():
 class MockWorld:
     def __init__(self):
         self.map = Mock()
-        self.map.region_names = {}
+        self.map.regions = {}
         self.map.sect_regions = {}
         self.avatar_manager = Mock()
         self.avatar_manager.avatars = {}
@@ -107,10 +107,10 @@ def test_resolve_query_unsupported_type():
 
 def test_resolve_region_mock(mock_world):
     """测试区域解析（Mock环境）"""
-    # 准备数据
+    # 准备数据 - 使用 regions[id] 字典而非 region_names
     mock_region = Mock()
     mock_region.name = "青云山"
-    mock_world.map.region_names = {"青云山": mock_region}
+    mock_world.map.regions = {1: mock_region}
     
     # 1. 精确匹配
     res = resolve_query("青云山", world=mock_world, expected_types=[type(mock_region)]) # 动态类型模拟 Region


### PR DESCRIPTION
## Summary
Remove the redundant `region_names` dictionary and use `regions.values()` traversal instead.

## Problem
When `HistoryManager` modifies region names (e.g., "沧澜城" → "沧澜潮汐城"), the `region_names` lookup dictionary was not being synced. This caused `resolve_query` to fail when LLM returns the new region name.

**Failing log:**
```
2026-01-17 23:48:42 - WARNING - 非法动作: Avatar(name=苏梦蝶,id=jmW21eSD) 的动作 MoveToRegion 参数={'region': '沧澜潮汐城'} 无法启动，原因=无法解析区域: 沧澜潮汐城
```

## Solution
Instead of fixing the sync issue by adding more code, we remove the redundant data structure entirely:

- **Before**: Two indexes maintained - `regions[id]` and `region_names[name]` (requires manual sync)
- **After**: Single source of truth - `regions[id]` only, name lookup via iteration

## Changes
- `resolution.py`: `_resolve_region` now iterates `regions.values()` to find by name
- `load_map.py`: Remove `region_names` population
- `map.py`: Remove `region_names` and other unused `*_region_names` dictionaries
- Tests updated to use `resolve_query` instead of checking `region_names` dict

## Why This Is Better
1. Eliminates the sync bug entirely (no sync needed)
2. Simpler code, fewer moving parts
3. Negligible performance impact (region count is ~50-100, iteration is O(n) but n is small)

## Test Plan
- All 328 tests pass
- Added regression test `test_move_to_region_after_history_rename` that directly tests the failing scenario:
  - History renames "沧澜城" → "沧澜潮汐城"
  - `MoveToRegion.can_start("沧澜潮汐城")` should succeed
- Added assertions in `test_history_influence` verifying `resolve_query` finds regions by new names