### PR TITLE
fix: mock StoryTeller to prevent flaky test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def mock_llm_managers():
          patch("src.classes.nickname.process_avatar_nickname", new_callable=AsyncMock) as mock_nick, \
          patch("src.classes.relation_resolver.RelationResolver.run_batch", new_callable=AsyncMock) as mock_rr, \
          patch("src.classes.history.HistoryManager.apply_history_influence", new_callable=AsyncMock) as mock_hist, \
+         patch("src.classes.story_teller.StoryTeller.tell_story", new_callable=AsyncMock) as mock_story, \
          patch("src.utils.llm.config.LLMConfig.from_mode", return_value=mock_llm_config) as mock_config:
         
         mock_ai.decide = AsyncMock(return_value={})
@@ -90,6 +91,7 @@ def mock_llm_managers():
         mock_nick.return_value = None
         mock_rr.return_value = []
         mock_hist.return_value = None
+        mock_story.return_value = "测试故事"
 
         yield {
             "ai": mock_ai,
@@ -97,6 +99,7 @@ def mock_llm_managers():
             "nick": mock_nick,
             "rr": mock_rr,
             "hist": mock_hist,
+            "story": mock_story,
             "config": mock_config
         }
 


### PR DESCRIPTION
## Summary
Fix flaky test `test_passive_update_loop` in `test_elixir.py`.

## Problem
The test randomly fails in CI because:
1. `sim.step()` has a chance to trigger misfortune events
2. Misfortune calls `StoryTeller.tell_story()` which makes real LLM API calls
3. `mock_llm_managers` fixture didn't mock `StoryTeller`
4. CI environment can't reach `test.api` domain → test fails

## Fix
Add `StoryTeller.tell_story` to `mock_llm_managers` fixture in `conftest.py`.

## Test Plan
- All 327 tests pass locally
- The previously flaky test now consistently passes