### PR TITLE
fix(web): decouple manual pause state from system pause behavior

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -69,7 +69,9 @@ watch(gameInitialized, (val) => {
       showSplash.value = false
     }
 
+    // 设置前端状态并恢复后端
     isManualPaused.value = false
+    systemApi.resumeGame().catch(console.error)
     openedFromSplash.value = false // 游戏开始，清除 Splash 来源标记
   }
 })

--- a/web/src/stores/system.ts
+++ b/web/src/stores/system.ts
@@ -46,18 +46,27 @@ export const useSystemStore = defineStore('system', () => {
     isInitialized.value = val;
   }
 
+  // 切换手动暂停状态（用户点击暂停按钮时调用）
   async function togglePause() {
-    if (isManualPaused.value) {
-      await resume();
-    } else {
-      await pause();
+    const newState = !isManualPaused.value;
+    isManualPaused.value = newState;
+    try {
+      if (newState) {
+        await systemApi.pauseGame();
+      } else {
+        await systemApi.resumeGame();
+      }
+    } catch (e) {
+      // API 失败时回滚状态
+      isManualPaused.value = !newState;
+      console.error(e);
     }
   }
 
+  // 仅调用后端 API，不修改 isManualPaused（用于菜单打开/关闭等系统行为）
   async function pause() {
     try {
       await systemApi.pauseGame();
-      isManualPaused.value = true;
     } catch (e) {
       console.error(e);
     }
@@ -66,7 +75,6 @@ export const useSystemStore = defineStore('system', () => {
   async function resume() {
     try {
       await systemApi.resumeGame();
-      isManualPaused.value = false;
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
## Summary

Fixes the bug where the UI shows "已暂停" (paused) while the game is still running in the background.

## Problem

The `isManualPaused` state was incorrectly used for two different purposes:
1. **User manual pause** - when user clicks the pause button
2. **System pause** - when menu opens (automatic pause)

When opening the menu, `pause()` was called which set `isManualPaused = true`. After closing the menu, the code checked `isManualPaused` and found it `true`, so it didn't call `resume()`. This caused:
- UI showing "已暂停" (because `isManualPaused = true`)
- But backend might already be running (due to other code paths calling resume API)

Additionally, there were **3 overlapping watches** in `useGameControl.ts` monitoring the same states, causing confusing and redundant API calls.

## Solution

1. **`systemStore.ts`**: 
   - `pause()` / `resume()` now only call backend API, no longer modify `isManualPaused`
   - `togglePause()` uses optimistic update (set state first, then API call, rollback on failure)

2. **`useGameControl.ts`**: 
   - Consolidated 3 watches into 1 clean watch
   - Menu open/close only affects backend pause state, never touches `isManualPaused`

3. **`App.vue`**: 
   - Explicitly calls `resumeGame()` API when game initializes

## Behavior After Fix

| Action | `isManualPaused` | Backend `is_paused` |
|--------|------------------|---------------------|
| User clicks pause button | `true` | `true` |
| User clicks play button | `false` | `false` |
| Menu opens | unchanged | `true` |
| Menu closes (not manually paused) | unchanged | `false` |
| Menu closes (manually paused) | unchanged | stays `true` |