### PR TITLE
chore: add pytest-cov to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ websockets>=11.0
 # Testing
 pytest>=8.0.0
 pytest-asyncio>=0.23.0  # Required for async tests
-httpx>=0.27.0  # Required for FastAPI TestClient
+pytest-cov>=4.1.0       # Required for coverage reporting
+httpx>=0.27.0           # Required for FastAPI TestClient


### PR DESCRIPTION
Adds pytest-cov>=4.1.0 to requirements.txt for coverage reporting.

Closes #42