### PR TITLE
chore: configure coverage settings in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,21 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 norecursedirs = ["tmp", "assets", "node_modules", "dist", "build", "web", "tools"]
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+    "src/__pycache__/*",
+    "src/*/__pycache__/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]
+show_missing = true


### PR DESCRIPTION
Configures pytest-cov settings in pyproject.toml:

- `[tool.coverage.run]`: Set source to `src/`, enable branch coverage
- `[tool.coverage.report]`: Exclude common non-testable patterns, show missing lines

Closes #43