### PR TITLE
test: add fixed_random_seed fixture with autouse=True

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,18 @@
 import pytest
+import random
 from unittest.mock import MagicMock, AsyncMock, patch
 
 from src.classes.map import Map
+
+
+@pytest.fixture(autouse=True)
+def fixed_random_seed():
+    """
+    Ensure all tests have deterministic random behavior.
+    This fixture is automatically applied to all tests.
+    """
+    random.seed(42)
+    yield
 from src.classes.tile import TileType, Tile
 from src.classes.world import World
 from src.classes.calendar import Month, Year, create_month_stamp


### PR DESCRIPTION
Adds a `fixed_random_seed` fixture that automatically applies to all tests, ensuring deterministic random behavior.

This prevents flaky tests caused by random number generation in combat results, AI decisions, event triggers, etc.

```python
@pytest.fixture(autouse=True)
def fixed_random_seed():
    random.seed(42)
    yield
```

Closes #44