### PR TITLE
fix: use sect_id instead of sect in fortune technique filter

### DIFF
--- a/src/classes/fortune.py
+++ b/src/classes/fortune.py
@@ -280,12 +280,10 @@ def _get_fortune_technique_for_avatar(avatar: Avatar) -> Optional[Technique]:
     """
     candidates: list[Technique] = []
     
-    # 确定允许的宗门范围
-    allowed_sects: set[Optional[str]] = {None, ""}
+    # 确定允许的宗门 ID 范围
+    allowed_sect_ids: set[Optional[int]] = {None}
     if avatar.sect is not None:
-        sect_name = avatar.sect.name.strip() if avatar.sect.name else None
-        if sect_name:
-            allowed_sects.add(sect_name)
+        allowed_sect_ids.add(avatar.sect.id)
     
     # 筛选功法
     for t in techniques_by_id.values():
@@ -294,8 +292,7 @@ def _get_fortune_technique_for_avatar(avatar: Avatar) -> Optional[Technique]:
             continue
         
         # 宗门限制：宗门弟子只能获得本宗门或无宗门的功法
-        tech_sect = t.sect.strip() if t.sect else None
-        if tech_sect not in allowed_sects:
+        if t.sect_id not in allowed_sect_ids:
             continue
         
         # condition 检查


### PR DESCRIPTION
## Summary
Fix `AttributeError: 'Technique' object has no attribute 'sect'` in fortune event.

## Problem
PR #32 changed `Technique.sect` (str) to `Technique.sect_id` (int), but `fortune.py` was not updated:

```python
# fortune.py:297 - using old attribute
tech_sect = t.sect.strip() if t.sect else None  # ❌ AttributeError
```

**Failing log:**
```
AttributeError: 'Technique' object has no attribute 'sect'
```

This is a **flaky test** because it only fails when:
1. Fortune event randomly triggers (0.5% chance per step)
2. AND the fortune type is TECHNIQUE

## Fix
Update `_get_fortune_technique_for_avatar()` to use `sect_id` (int) instead of `sect` (str):

```python
# Before (broken)
allowed_sects: set[Optional[str]] = {None, ""}
if avatar.sect is not None:
    sect_name = avatar.sect.name.strip() if avatar.sect.name else None
    allowed_sects.add(sect_name)
tech_sect = t.sect.strip() if t.sect else None

# After (fixed)
allowed_sect_ids: set[Optional[int]] = {None}
if avatar.sect is not None:
    allowed_sect_ids.add(avatar.sect.id)
if t.sect_id not in allowed_sect_ids:
    continue
```

## Test Plan
- All 330 tests pass
- Ran `test_simulator_step_moves_avatar_and_sets_tile` 20 times consecutively - all passed