### PR TITLE
feat: add Ollama preset for local LLM deployment

### DIFF
--- a/web/src/components/game/panels/system/LLMConfigPanel.vue
+++ b/web/src/components/game/panels/system/LLMConfigPanel.vue
@@ -46,6 +46,13 @@ const presets = [
     base_url: 'https://openrouter.ai/api/v1',
     model_name: 'anthropic/claude-3.5-sonnet',
     fast_model_name: 'google/gemini-3-flash'
+  },
+  {
+    name: 'Ollama (本地)',
+    base_url: 'http://localhost:11434/v1',
+    model_name: 'qwen2.5:7b',
+    fast_model_name: 'qwen2.5:7b',
+    isLocal: true
   }
 ]
 
@@ -66,7 +73,13 @@ function applyPreset(preset: typeof presets[0]) {
   config.value.base_url = preset.base_url
   config.value.model_name = preset.model_name
   config.value.fast_model_name = preset.fast_model_name
-  message.info(`已应用 ${preset.name} 预设 (请填写 API Key)`)
+  // Ollama doesn't require a real API key, auto-fill a placeholder.
+  if ('isLocal' in preset && preset.isLocal) {
+    config.value.api_key = 'ollama'
+    message.info(`已应用 ${preset.name} 预设 (请确保 Ollama 已启动)`)
+  } else {
+    message.info(`已应用 ${preset.name} 预设 (请填写 API Key)`)
+  }
 }
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary

Add Ollama preset button to the LLM configuration panel, allowing users to easily configure local Ollama deployment.
<img width="1988" height="1346" alt="CleanShot 2026-01-19 at 23 29 31@2x" src="https://github.com/user-attachments/assets/bdfce136-3de7-4523-9fee-e53f0ec7ad7c" />

## Changes

- Add "Ollama (本地)" preset with default configuration:
  - Base URL: `http://localhost:11434/v1`
  - Model: `qwen2.5:7b` (can be changed to any installed model)
- Auto-fill API key with placeholder value since Ollama doesn't require authentication
- Show different hint message for local preset ("请确保 Ollama 已启动")

## Usage

1. Start Ollama locally: `ollama serve`
2. Pull a model: `ollama pull qwen2.5:7b`
3. Click "Ollama (本地)" preset button in the LLM config panel
4. Change model name if needed
5. Click "测试连通性并保存"

Closes user request for Ollama support.