### PR TITLE
feat(dev): add claude-compatible skills for git-pr and test-validate

### DIFF
--- a/.claude/skills/git-pr/SKILL.md
+++ b/.claude/skills/git-pr/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: git-pr
+description: Create a pull request with proper remote handling
+---
+
+## Pre-flight
+
+```bash
+git remote -v
+# If origin URL is outdated, fix it:
+# git remote set-url origin https://github.com/AI-Cultivation/cultivation-world-simulator.git
+```
+
+## Commands
+
+```bash
+git checkout main && git pull origin main
+git checkout -b <github-username>/<branch-name>
+git add <files>
+git commit -m "<type>: <description>"
+git push -u origin <github-username>/<branch-name>
+gh pr create --head <github-username>/<branch-name> --base main --title "<type>: <description>" --body "<body>"
+```
+
+## Notes
+
+- Always branch off from `main`, not from current branch
+- Follow PR template in `.github/PULL_REQUEST_TEMPLATE.md`
+- `<github-username>`: e.g., `xzhseh`
+- `<type>`: `feat` | `fix` | `refactor` | `test` | `docs`

--- a/.claude/skills/test-validate/SKILL.md
+++ b/.claude/skills/test-validate/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: test-validate
+description: Run Python tests using the project venv
+---
+
+## Commands
+
+```bash
+# Run all tests
+.venv/bin/pytest
+
+# Run specific test file
+.venv/bin/pytest tests/test_<name>.py -v
+
+# Run with coverage
+.venv/bin/pytest --cov=src
+
+# Run server (dev mode)
+.venv/bin/python src/server/main.py --dev
+```


### PR DESCRIPTION
## Summary

Add two Claude/OpenCode compatible skills for this project:
- `git-pr`: SOP for creating PRs with proper remote handling
- `test-validate`: SOP for running Python tests using project venv

## Test Plan

Skills are loaded automatically by OpenCode/Claude Code from `.claude/skills/*/SKILL.md`.