### PR TITLE
Add realm-delta risk gating for cave-heaven seize attempts

### DIFF
--- a/src/classes/mutual_action/occupy.py
+++ b/src/classes/mutual_action/occupy.py
@@ -16,6 +16,9 @@ from src.classes.death import handle_death
 from src.classes.death_reason import DeathReason
 from src.classes.action.event_helper import EventHelper
 from src.utils.resolution import resolve_query
+from src.utils.config import CONFIG
+from src.run.log import get_logger
+from src.systems.cultivation import REALM_RANK
 
 if TYPE_CHECKING:
     from src.classes.core.avatar import Avatar
@@ -29,39 +32,129 @@ class Occupy(MutualAction):
     占据指定的洞府。如果是无主洞府直接占据；如果是有主洞府，则发起抢夺。
     对方拒绝则进入战斗，进攻方胜利则洞府易主。
     """
-    
+
     # 多语言 ID
     ACTION_NAME_ID = "occupy_action_name"
     DESC_ID = "occupy_description"
     REQUIREMENTS_ID = "occupy_requirements"
     STORY_PROMPT_ID = "occupy_story_prompt"
-    
+
     # 不需要翻译的常量
     EMOJI = "🚩"
     PARAMS = {"region_name": "str"}
     FEEDBACK_ACTIONS = ["Yield", "Reject"]
-    
+
     # 自定义反馈标签
     FEEDBACK_LABEL_IDS = {"Yield": "feedback_yield", "Reject": "feedback_reject"}
-    
+
     IS_MAJOR = True
     ACTION_CD_MONTHS = 6
+
+    DEFAULT_SOFT_BLOCK_REALM_DELTA = 1
+    DEFAULT_HARD_BLOCK_REALM_DELTA = 2
+    DEFAULT_SOFT_DECAY_MULTIPLIER = 0.5
+    DEFAULT_RECKLESS_OVERRIDE_PROB = 0.1
+    DEFAULT_RECKLESS_TRAIT_KEYS = ("ADVENTUROUS", "AGGRESSIVE", "RASH")
+    DEFAULT_RECKLESS_TRAIT_NAMES = ("冒险", "好斗", "鲁莽")
 
     def _get_region_and_host(self, region_name: str) -> tuple[CultivateRegion | None, "Avatar | None", str]:
         """解析区域并获取主人"""
         res = resolve_query(region_name, self.world, expected_types=[CultivateRegion])
-        
+
         # resolve_query 可能返回普通 Region，这里需要严格检查是否为 CultivateRegion
         region = res.obj
-        
+
         if not res.is_valid or region is None:
             return None, None, t("Cannot find region: {region}", region=region_name)
-            
+
         if not isinstance(region, CultivateRegion):
             return None, None, t("{region} is not a cultivation area, cannot occupy",
                                 region=region.name if region else t("wilderness"))
-            
+
         return region, region.host_avatar, ""
+
+    def _risk_cfg_value(self, key: str, default):
+        risk_cfg = getattr(CONFIG, "cave_heaven_risk", None)
+        if risk_cfg is None:
+            return default
+        return getattr(risk_cfg, key, default)
+
+    def _is_reckless_avatar(self, avatar: "Avatar") -> bool:
+        configured_keys = self._risk_cfg_value("reckless_trait_keys", self.DEFAULT_RECKLESS_TRAIT_KEYS)
+        configured_names = self._risk_cfg_value("reckless_trait_names", self.DEFAULT_RECKLESS_TRAIT_NAMES)
+        reckless_keys = {str(k).upper() for k in configured_keys}
+        reckless_names = {str(n) for n in configured_names}
+
+        for persona in avatar.personas:
+            trait_key = str(getattr(persona, "key", "")).strip()
+            if trait_key:
+                if trait_key.upper() in reckless_keys:
+                    return True
+                continue
+
+            trait_name = str(getattr(persona, "name", "")).strip()
+            if trait_name and trait_name in reckless_names:
+                return True
+
+        return False
+
+    def _log_risk_decision(
+        self,
+        reason: str,
+        npc: "Avatar",
+        owner: "Avatar",
+        realm_delta: int,
+    ) -> None:
+        if not self._risk_cfg_value("debug_log", False):
+            return
+
+        logger = get_logger().logger
+        logger.info(
+            "occupy_risk reason=%s npc_id=%s npc_realm=%s owner_id=%s owner_realm=%s realm_delta=%s",
+            reason,
+            npc.id,
+            npc.cultivation_progress.realm.name,
+            owner.id,
+            owner.cultivation_progress.realm.name,
+            realm_delta,
+        )
+
+    def _risk_evaluator(self, npc: "Avatar", owner: "Avatar | None") -> tuple[bool, float, str]:
+        if owner is None:
+            return True, 1.0, "owner_none"
+
+        npc_realm = npc.cultivation_progress.realm
+        owner_realm = owner.cultivation_progress.realm
+        realm_delta = REALM_RANK.get(owner_realm, 0) - REALM_RANK.get(npc_realm, 0)
+
+        hard_block_delta = int(
+            self._risk_cfg_value("hard_block_realm_delta", self.DEFAULT_HARD_BLOCK_REALM_DELTA)
+        )
+        soft_block_delta = int(
+            self._risk_cfg_value("soft_block_realm_delta", self.DEFAULT_SOFT_BLOCK_REALM_DELTA)
+        )
+        soft_decay = float(
+            self._risk_cfg_value("soft_decay_multiplier", self.DEFAULT_SOFT_DECAY_MULTIPLIER)
+        )
+        reckless_override_prob = float(
+            self._risk_cfg_value("reckless_override_prob", self.DEFAULT_RECKLESS_OVERRIDE_PROB)
+        )
+
+        is_reckless = self._is_reckless_avatar(npc)
+
+        if realm_delta >= hard_block_delta:
+            if is_reckless and random.random() < reckless_override_prob:
+                self._log_risk_decision("override_allowed", npc, owner, realm_delta)
+                return True, 1.0, "override_allowed"
+
+            self._log_risk_decision("hard_block", npc, owner, realm_delta)
+            return False, 0.0, "hard_block"
+
+        if realm_delta == soft_block_delta:
+            self._log_risk_decision("soft_decay", npc, owner, realm_delta)
+            return True, soft_decay, "soft_decay"
+
+        return True, 1.0, "normal"
 
     def can_start(self, region_name: str) -> tuple[bool, str]:
         region, host, err = self._get_region_and_host(region_name)
@@ -69,6 +162,16 @@ class Occupy(MutualAction):
             return False, err
         if region.host_avatar == self.avatar:
             return False, t("Already the owner of this cave dwelling")
+
+        allowed, weight_multiplier, _reason = self._risk_evaluator(self.avatar, host)
+        if not allowed:
+            return False, t("Risk too high to seize this cave dwelling")
+
+        # Current action scheduler has no explicit weight field. For soft-block, apply
+        # proportional acceptance probability to reduce frequency while keeping non-zero chance.
+        if weight_multiplier < 1.0 and random.random() > weight_multiplier:
+            return False, t("Risk too high to seize this cave dwelling")
+
         return super().can_start(target_avatar=host)
 
     def start(self, region_name: str) -> Event:
@@ -102,37 +205,37 @@ class Occupy(MutualAction):
         """处理反馈结果"""
         region_name = getattr(self, "target_region_name", self.avatar.tile.location_name)
         region, _, _ = self._get_region_and_host(region_name)
-        
+
         if feedback_name == "Yield":
             # 对方让步：直接转移所有权
             if region:
                 self.avatar.occupy_region(region)
-            
+
             # 共用一个事件
             event_text = t("{initiator} forced {target} to yield {region}",
                           initiator=self.avatar.name, target=target_avatar.name, region=region_name)
             event = Event(
-                self.world.month_stamp, 
-                event_text, 
+                self.world.month_stamp,
+                event_text,
                 related_avatars=[self.avatar.id, target_avatar.id],
                 is_major=True
             )
             # 统一推送，避免重复
             EventHelper.push_pair(event, initiator=self.avatar, target=target_avatar, to_sidebar_once=True)
-            
+
             self._last_result = None
-            
+
         elif feedback_name == "Reject":
             # 对方拒绝：进入战斗
             winner, loser, loser_dmg, winner_dmg = decide_battle(self.avatar, target_avatar)
             loser.hp.reduce(loser_dmg)
             winner.hp.reduce(winner_dmg)
-            
+
             # 进攻方胜利则洞府易主
             attacker_won = winner == self.avatar
             if attacker_won and region:
                 self.avatar.occupy_region(region)
-            
+
             self._last_result = (winner, loser, loser_dmg, winner_dmg, region_name, attacker_won)
 
     async def finish(self, region_name: str) -> list[Event]:
@@ -140,16 +243,16 @@ class Occupy(MutualAction):
         res = self._last_result if hasattr(self, '_last_result') else None
         if res is None:
             return []
-        
+
         # res format from occupy: (winner, loser, l_dmg, w_dmg, r_name, attacker_won)
         winner, loser, l_dmg, w_dmg, r_name, attacker_won = res
         battle_res = (winner, loser, l_dmg, w_dmg)
-        
+
         target = loser if winner == self.avatar else winner
-        
+
         start_text = t("{initiator} attempted to seize {target}'s cave dwelling {region}, {target} rejected and engaged in battle",
                       initiator=self.avatar.name, target=target.name, region=r_name)
-        
+
         postfix = t(", successfully seized {region}", region=r_name) if attacker_won else t(", defended {region}", region=r_name)
 
         from src.systems.battle import handle_battle_finish

--- a/static/config.yml
+++ b/static/config.yml
@@ -67,3 +67,18 @@ system:
 
 play:
   base_benefit_probability: 0.05
+
+cave_heaven_risk:
+  soft_block_realm_delta: 1
+  hard_block_realm_delta: 2
+  soft_decay_multiplier: 0.5
+  reckless_override_prob: 0.1
+  reckless_trait_keys:
+    - ADVENTUROUS
+    - AGGRESSIVE
+    - RASH
+  reckless_trait_names:
+    - "冒险"
+    - "好斗"
+    - "鲁莽"
+  debug_log: false

--- a/static/locales/zh-CN/LC_MESSAGES/messages.po
+++ b/static/locales/zh-CN/LC_MESSAGES/messages.po
@@ -2775,3 +2775,7 @@ msgid ""
 "Weapon {name}'s weapon_type '{weapon_type_str}' is invalid, must be a valid "
 "weapon type"
 msgstr "武器 {name} 的weapon_type '{weapon_type_str}' 无效，必须是有效的兵器类型"
+
+msgid "Risk too high to seize this cave dwelling"
+msgstr "风险过高，放弃争夺该洞府"
+

--- a/tests/test_occupy_risk.py
+++ b/tests/test_occupy_risk.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.classes.action_runtime import ActionPlan
+from src.classes.core.avatar import Avatar, Gender
+from src.classes.age import Age
+from src.classes.environment.region import CultivateRegion
+from src.classes.mutual_action.occupy import Occupy
+from src.classes.root import Root
+from src.classes.alignment import Alignment
+from src.systems.cultivation import Realm
+from src.systems.time import Year, Month, create_month_stamp
+from src.utils.id_generator import get_avatar_id
+
+
+def _create_avatar(world, name: str, realm: Realm, personas: list | None = None) -> Avatar:
+    avatar = Avatar(
+        world=world,
+        name=name,
+        id=get_avatar_id(),
+        birth_month_stamp=create_month_stamp(Year(2000), Month.JANUARY),
+        age=Age(20, realm),
+        gender=Gender.MALE,
+        pos_x=0,
+        pos_y=0,
+        root=Root.GOLD,
+        personas=personas or [],
+        alignment=Alignment.RIGHTEOUS,
+    )
+    avatar.cultivation_progress.realm = realm
+    world.avatar_manager.register_avatar(avatar)
+    return avatar
+
+
+def _add_cultivate_region(world, name: str = "RiskTestCave") -> CultivateRegion:
+    region = CultivateRegion(id=999001, name=name, desc="test", essence_density=1)
+    world.map.regions[region.id] = region
+    return region
+
+
+class _PersonaStub:
+    def __init__(self, key: str = "", name: str = ""):
+        self.key = key
+        self.name = name
+
+
+def test_occupy_risk_owner_none_allowed(base_world):
+    challenger = _create_avatar(base_world, "ChallengerA", Realm.Qi_Refinement)
+    action = Occupy(challenger, base_world)
+
+    allowed, multiplier, reason = action._risk_evaluator(challenger, None)
+
+    assert allowed is True
+    assert multiplier == 1.0
+    assert reason == "owner_none"
+
+
+def test_occupy_risk_realm_delta_soft_decay(base_world):
+    challenger = _create_avatar(base_world, "ChallengerB", Realm.Qi_Refinement)
+    owner = _create_avatar(base_world, "OwnerB", Realm.Foundation_Establishment)
+    action = Occupy(challenger, base_world)
+
+    allowed, multiplier, reason = action._risk_evaluator(challenger, owner)
+
+    assert allowed is True
+    assert multiplier == 0.5
+    assert reason == "soft_decay"
+
+
+def test_occupy_risk_realm_delta_hard_block_non_reckless(base_world):
+    challenger = _create_avatar(base_world, "ChallengerC", Realm.Qi_Refinement)
+    owner = _create_avatar(base_world, "OwnerC", Realm.Core_Formation)
+    action = Occupy(challenger, base_world)
+
+    allowed, multiplier, reason = action._risk_evaluator(challenger, owner)
+
+    assert allowed is False
+    assert multiplier == 0.0
+    assert reason == "hard_block"
+
+
+def test_occupy_risk_realm_delta_hard_block_reckless_override_allowed(base_world):
+    personas = [_PersonaStub(key="RASH", name="鲁莽")]
+    challenger = _create_avatar(base_world, "ChallengerD", Realm.Qi_Refinement, personas=personas)
+    owner = _create_avatar(base_world, "OwnerD", Realm.Core_Formation)
+    action = Occupy(challenger, base_world)
+
+    with patch("src.classes.mutual_action.occupy.random.random", return_value=0.01):
+        allowed, multiplier, reason = action._risk_evaluator(challenger, owner)
+
+    assert allowed is True
+    assert multiplier == 1.0
+    assert reason == "override_allowed"
+
+
+def test_occupy_risk_realm_delta_hard_block_reckless_override_failed(base_world):
+    personas = [_PersonaStub(key="RASH", name="鲁莽")]
+    challenger = _create_avatar(base_world, "ChallengerE", Realm.Qi_Refinement, personas=personas)
+    owner = _create_avatar(base_world, "OwnerE", Realm.Core_Formation)
+    action = Occupy(challenger, base_world)
+
+    with patch("src.classes.mutual_action.occupy.random.random", return_value=0.99):
+        allowed, multiplier, reason = action._risk_evaluator(challenger, owner)
+
+    assert allowed is False
+    assert multiplier == 0.0
+    assert reason == "hard_block"
+
+
+def test_occupy_can_start_soft_decay_probability_applies(base_world):
+    challenger = _create_avatar(base_world, "ChallengerF", Realm.Qi_Refinement)
+    owner = _create_avatar(base_world, "OwnerF", Realm.Foundation_Establishment)
+    region = _add_cultivate_region(base_world, name="SoftDecayCave")
+    region.host_avatar = owner
+
+    action = Occupy(challenger, base_world)
+
+    with patch("src.classes.mutual_action.occupy.random.random", return_value=0.9):
+        can_start, reason = action.can_start(region_name=region.name)
+
+    assert can_start is False
+    assert "Risk too high" in reason
+
+
+def test_commit_next_plan_fallback_when_occupy_filtered(base_world):
+    challenger = _create_avatar(base_world, "ChallengerG", Realm.Qi_Refinement)
+    owner = _create_avatar(base_world, "OwnerG", Realm.Core_Formation)
+    region = _add_cultivate_region(base_world, name="FallbackCave")
+    region.host_avatar = owner
+
+    challenger.planned_actions = [
+        ActionPlan("Occupy", {"region_name": region.name}),
+        ActionPlan("Cultivate", {}),
+    ]
+
+    start_event = challenger.commit_next_plan()
+
+    assert challenger.current_action is not None
+    assert challenger.current_action.action.__class__.__name__ == "Cultivate"
+    assert start_event is not None
+
+


### PR DESCRIPTION
## Summary
当前低境界 NPC 经常对明显强于自己的洞天主人发起争夺，造成高频“无意义送死”。  
本 PR 在 `Occupy.can_start` 引入按“大境界差（realm_delta）”的风险评估：
- **硬拦截**：当 `realm_delta >= 2`（洞天主人高 ≥2 大境界）默认禁止挑战
- **莽夫例外**：若 NPC 命中“鲁莽/冒险/好斗”等 trait，可按小概率继续挑战（可配置）
- **软衰减**：当 `realm_delta == 1` 用 `soft_decay_multiplier` 做概率接受，降低频率但保留小概率
- 可选 debug log（默认关闭）

<!-- Brief description of what this PR does -->
新增 `static/config.yml` 配置块 `cave_heaven_risk`（均可调参）：
- hard_block_realm_delta=2, soft_block_realm_delta=1
- soft_decay_multiplier=0.5
- reckless_override_prob=0.1
- reckless_trait_keys / reckless_trait_names
- debug_log=false

## Test Plan
- `python -m pytest -v --cov=src --cov-report=term --cov-fail-under=60`
- 新增 `tests/test_occupy_risk.py` 覆盖 owner=None、soft/hard 分支、莽夫概率分支、以及 commit 回退不死锁
- 
<!-- How was this tested? -->
python 运行，然后直接打开程序运行了3年，没啥大bug