### PR TITLE
fix: 修复 Docker 构建时缺少 tools 目录的问题

### DIFF
--- a/deploy/Dockerfile.backend
+++ b/deploy/Dockerfile.backend
@@ -21,6 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt -i https://pypi.tuna.tsinghua
 COPY src/ ./src/
 COPY static/ ./static/
 COPY assets/ ./assets/
+COPY tools/ ./tools/
 
 # 创建必要的目录
 RUN mkdir -p /app/assets/saves /app/logs

--- a/deploy/Dockerfile.frontend
+++ b/deploy/Dockerfile.frontend
@@ -12,6 +12,10 @@ RUN npm ci
 
 # 复制前端源代码
 COPY web/ .
+
+# 复制 i18n 相关文件（前端构建需要）
+COPY tools/i18n/locales.json ../tools/i18n/locales.json
+
 # 构建前端
 RUN npm run build
 


### PR DESCRIPTION
## 问题描述

修复 #176

执行 `docker-compose up -d --build` 时，前端构建和后端启动都会失败，因为 Dockerfile 没有复制 `tools/` 目录。

## 修改内容

### deploy/Dockerfile.frontend
- 添加复制 `tools/i18n/locales.json` 文件，解决前端构建时找不到 `locales.json` 的问题

### deploy/Dockerfile.backend  
- 添加复制整个 `tools/` 目录，解决后端启动时找不到 `tools.i18n.locale_registry` 模块的问题

## 测试

已在本地测试，`docker-compose up -d --build` 可以正常构建并启动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)