### PR TITLE
feat: add Anthropic native API format support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ json5>=0.9.0
 fastapi>=0.100.0
 uvicorn>=0.20.0
 websockets>=11.0
+requests>=2.28.0
 
 # Testing
 pytest>=8.0.0

--- a/src/config/settings_schema.py
+++ b/src/config/settings_schema.py
@@ -46,6 +46,7 @@ class LLMProfile(BaseModel):
     mode: str = "default"
     max_concurrent_requests: int = 10
     has_api_key: bool = False
+    api_format: str = "openai"  # "openai" 或 "anthropic"
 
 
 class LLMConfigView(LLMProfile):
@@ -68,6 +69,7 @@ class LLMSettingsUpdate(BaseModel):
     mode: str
     max_concurrent_requests: int = 10
     clear_api_key: bool = False
+    api_format: str = "openai"  # "openai" 或 "anthropic"
 
 
 class NewGameDefaults(BaseModel):

--- a/src/config/settings_service.py
+++ b/src/config/settings_service.py
@@ -140,6 +140,7 @@ class SettingsService:
             mode=update.mode,
             max_concurrent_requests=update.max_concurrent_requests,
             has_api_key=settings.llm.profile.has_api_key,
+            api_format=update.api_format,
         )
 
         if update.clear_api_key:
@@ -172,6 +173,7 @@ class SettingsService:
             mode=update.mode,
             max_concurrent_requests=update.max_concurrent_requests,
             has_api_key=bool(candidate_key),
+            api_format=update.api_format,
         )
         return profile, candidate_key
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1752,6 +1752,7 @@ def test_llm_connection(req: LLMSettingsUpdate):
             base_url=profile.base_url,
             api_key=api_key,
             model_name=profile.model_name,
+            api_format=profile.api_format,
         )
 
         success, error_msg = test_connectivity(config=config)

--- a/src/utils/llm/client.py
+++ b/src/utils/llm/client.py
@@ -1,11 +1,11 @@
 """LLM 客户端核心调用逻辑"""
 
 import json
-import urllib.request
-import urllib.error
 import asyncio
 from pathlib import Path
 from typing import Optional
+
+import requests as _requests
 
 from src.config import get_settings_service
 from src.run.log import log_llm_call
@@ -35,48 +35,95 @@ def _get_semaphore() -> asyncio.Semaphore:
     return _SEMAPHORE
 
 
-def _call_with_requests(config: LLMConfig, prompt: str) -> str:
-    """使用原生 urllib 调用 (OpenAI 兼容接口)"""
+def _call_openai(config: LLMConfig, prompt: str) -> str:
+    """使用 requests 库调用 (OpenAI 兼容接口)"""
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {config.api_key}",
         "User-Agent": "CultivationWorldSimulator/1.0"
     }
-    model_name = config.model_name
     data = {
-        "model": model_name,
+        "model": config.model_name,
         "messages": [{"role": "user", "content": prompt}]
     }
-    
+
     url = config.base_url
     if not url:
         raise ValueError("Base URL is required for requests mode (OpenAI Compatible)")
-        
+
     # URL 规范化处理：确保指向 chat/completions
     if "chat/completions" not in url:
         url = url.rstrip("/")
         url = f"{url}/chat/completions"
 
-    req = urllib.request.Request(
-        url, 
-        data=json.dumps(data).encode('utf-8'), 
-        headers=headers,
-        method="POST"
-    )
-    
     try:
-        # 设置超时时间为 120 秒，避免无限等待
-        with urllib.request.urlopen(req, timeout=120) as response:
-            result = json.loads(response.read().decode('utf-8'))
-            return result['choices'][0]['message']['content']
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode('utf-8')
-        raise Exception(f"HTTP_{e.code}::{error_body}")
-    except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
-        reason = getattr(e, 'reason', str(e))
-        raise Exception(f"NETWORK_ERROR::{reason}")
+        resp = _requests.post(url, json=data, headers=headers, timeout=120)
+        resp.raise_for_status()
+        result = resp.json()
+        return result['choices'][0]['message']['content']
+    except _requests.exceptions.HTTPError as e:
+        error_body = e.response.text if e.response is not None else str(e)
+        status_code = e.response.status_code if e.response is not None else 0
+        raise Exception(f"HTTP_{status_code}::{error_body}")
+    except (_requests.exceptions.ConnectionError, _requests.exceptions.Timeout) as e:
+        raise Exception(f"NETWORK_ERROR::{str(e)}")
     except Exception as e:
+        if str(e).startswith(("HTTP_", "NETWORK_ERROR::")):
+            raise
         raise Exception(f"UNKNOWN_ERROR::{str(e)}")
+
+
+def _call_anthropic(config: LLMConfig, prompt: str) -> str:
+    """使用 requests 库调用 (Anthropic 原生接口)"""
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": config.api_key,
+        "anthropic-version": "2023-06-01",
+        "User-Agent": "CultivationWorldSimulator/1.0"
+    }
+    data = {
+        "model": config.model_name,
+        "max_tokens": 4096,
+        "messages": [{"role": "user", "content": prompt}]
+    }
+
+    url = config.base_url
+    if not url:
+        raise ValueError("Base URL is required for Anthropic API")
+
+    # URL 规范化处理：确保指向 /v1/messages
+    if "/messages" not in url:
+        url = url.rstrip("/")
+        if not url.endswith("/v1"):
+            url = f"{url}/v1"
+        url = f"{url}/messages"
+
+    try:
+        resp = _requests.post(url, json=data, headers=headers, timeout=120)
+        resp.raise_for_status()
+        result = resp.json()
+        # Anthropic 响应格式: {"content": [{"type": "text", "text": "..."}]}
+        for block in result.get('content', []):
+            if block.get('type') == 'text':
+                return block['text']
+        raise Exception("UNKNOWN_ERROR::Anthropic 响应中未找到 text 内容")
+    except _requests.exceptions.HTTPError as e:
+        error_body = e.response.text if e.response is not None else str(e)
+        status_code = e.response.status_code if e.response is not None else 0
+        raise Exception(f"HTTP_{status_code}::{error_body}")
+    except (_requests.exceptions.ConnectionError, _requests.exceptions.Timeout) as e:
+        raise Exception(f"NETWORK_ERROR::{str(e)}")
+    except Exception as e:
+        if str(e).startswith(("HTTP_", "NETWORK_ERROR::", "UNKNOWN_ERROR::")):
+            raise
+        raise Exception(f"UNKNOWN_ERROR::{str(e)}")
+
+
+def _call_with_requests(config: LLMConfig, prompt: str) -> str:
+    """根据 api_format 分发到对应的调用实现"""
+    if config.api_format == "anthropic":
+        return _call_anthropic(config, prompt)
+    return _call_openai(config, prompt)
 
 
 async def call_llm(prompt: str, mode: LLMMode = LLMMode.NORMAL) -> str:
@@ -199,6 +246,11 @@ def test_connectivity(mode: LLMMode = LLMMode.NORMAL, config: Optional[LLMConfig
                     # 兼容 OpenAI 和大部分厂商的 {"error": {"message": "..."}}
                     if "error" in body_json and isinstance(body_json["error"], dict):
                         provider_msg = body_json["error"].get("message") or body_json["error"].get("msg") or body_str
+                    # 兼容 Anthropic 的 {"type": "error", "error": {"type": "...", "message": "..."}}
+                    elif body_json.get("type") == "error" and "error" in body_json:
+                        err_obj = body_json["error"]
+                        if isinstance(err_obj, dict):
+                            provider_msg = err_obj.get("message") or body_str
                     # 兼容部分直接 {"message": "..."} 的厂商
                     elif "message" in body_json:
                         provider_msg = body_json["message"]

--- a/src/utils/llm/config.py
+++ b/src/utils/llm/config.py
@@ -19,21 +19,22 @@ class LLMConfig:
     model_name: str
     api_key: str
     base_url: str
-    
+    api_format: str = "openai"  # "openai" 或 "anthropic"
+
     @classmethod
     def from_mode(cls, mode: LLMMode) -> 'LLMConfig':
         """
         根据模式创建配置，从 CONFIG 读取
-        
+
         Args:
             mode: LLM 调用模式
-            
+
         Returns:
             LLMConfig: 配置对象
         """
         profile, api_key = get_settings_service().get_llm_runtime_config()
         base_url = profile.base_url
-        
+
         # 根据模式选择模型
         model_name = ""
         if mode == LLMMode.FAST:
@@ -41,11 +42,12 @@ class LLMConfig:
         else:
             # NORMAL or DEFAULT fallback
             model_name = profile.model_name
-        
+
         return cls(
             model_name=model_name,
             api_key=api_key,
-            base_url=base_url
+            base_url=base_url,
+            api_format=getattr(profile, 'api_format', 'openai')
         )
 
 

--- a/web/src/components/game/panels/system/LLMConfigPanel.vue
+++ b/web/src/components/game/panels/system/LLMConfigPanel.vue
@@ -19,7 +19,8 @@ const config = ref<LLMConfigDTO>({
   model_name: '',
   fast_model_name: '',
   mode: 'default',
-  max_concurrent_requests: 10
+  max_concurrent_requests: 10,
+  api_format: 'openai'
 })
 
 const modeOptions = computed(() => [
@@ -28,30 +29,41 @@ const modeOptions = computed(() => [
   { label: t('llm.modes.fast'), value: 'fast', desc: t('llm.modes.fast_desc') }
 ])
 
+const apiFormatOptions = computed(() => [
+  { label: t('llm.formats.openai'), value: 'openai', desc: t('llm.formats.openai_desc') },
+  { label: t('llm.formats.anthropic'), value: 'anthropic', desc: t('llm.formats.anthropic_desc') }
+])
+
 const presets = computed(() => [
   {
     name: t('llm.presets.qwen'),
     base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
     model_name: 'qwen-plus',
     fast_model_name: 'qwen-flash',
+    api_format: 'openai',
     badge: 'recommended'
   },
   {
     name: t('llm.presets.gemini'),
-    // Note: The `/openai` suffix is required to use Google's OpenAI-compatible API.
-    // Our backend (src/utils/llm/client.py) uses OpenAI-compatible format with
-    // Bearer token auth and /chat/completions endpoint, so we need this suffix
-    // to make Google API accept OpenAI-style requests instead of native Gemini format.
     base_url: 'https://generativelanguage.googleapis.com/v1beta/openai/',
     model_name: 'gemini-3-pro-preview',
     fast_model_name: 'gemini-3-flash-preview',
+    api_format: 'openai',
     badge: 'recommended'
+  },
+  {
+    name: t('llm.presets.anthropic'),
+    base_url: 'https://api.anthropic.com',
+    model_name: 'claude-sonnet-4-20250514',
+    fast_model_name: 'claude-haiku-4-20250414',
+    api_format: 'anthropic'
   },
   {
     name: t('llm.presets.groq'),
     base_url: 'https://api.groq.com/openai/v1',
     model_name: 'llama-3.3-70b-versatile',
     fast_model_name: 'llama-3.1-8b-instant',
+    api_format: 'openai',
     badge: 'free'
   },
   {
@@ -59,43 +71,50 @@ const presets = computed(() => [
     base_url: 'https://api.cerebras.ai/v1',
     model_name: 'gpt-oss-120b',
     fast_model_name: 'llama3.1-8b',
+    api_format: 'openai',
     badge: 'free'
   },
   {
     name: t('llm.presets.openai'),
     base_url: 'https://api.openai.com/v1',
     model_name: 'gpt-4o',
-    fast_model_name: 'gpt-4o-mini'
+    fast_model_name: 'gpt-4o-mini',
+    api_format: 'openai'
   },
   {
     name: t('llm.presets.deepseek'),
     base_url: 'https://api.deepseek.com',
     model_name: 'deepseek-chat',
-    fast_model_name: 'deepseek-chat'
+    fast_model_name: 'deepseek-chat',
+    api_format: 'openai'
   },
   {
     name: t('llm.presets.minimax'),
     base_url: 'https://api.minimax.io/v1',
     model_name: 'MiniMax-M2.7',
-    fast_model_name: 'MiniMax-M2.5-highspeed'
+    fast_model_name: 'MiniMax-M2.5-highspeed',
+    api_format: 'openai'
   },
   {
     name: t('llm.presets.siliconflow'),
     base_url: 'https://api.siliconflow.cn/v1',
     model_name: 'Qwen/Qwen2.5-72B-Instruct',
-    fast_model_name: 'Qwen/Qwen2.5-7B-Instruct'
+    fast_model_name: 'Qwen/Qwen2.5-7B-Instruct',
+    api_format: 'openai'
   },
   {
     name: t('llm.presets.openrouter'),
     base_url: 'https://openrouter.ai/api/v1',
     model_name: 'anthropic/claude-3.5-sonnet',
-    fast_model_name: 'google/gemini-3-flash'
+    fast_model_name: 'google/gemini-3-flash',
+    api_format: 'openai'
   },
   {
     name: t('llm.presets.ollama'),
     base_url: 'http://localhost:11434/v1',
     model_name: 'qwen2.5:7b',
     fast_model_name: 'qwen2.5:7b',
+    api_format: 'openai',
     isLocal: true
   }
 ])
@@ -111,7 +130,8 @@ async function fetchConfig() {
       model_name: res.model_name,
       fast_model_name: res.fast_model_name,
       mode: res.mode,
-      max_concurrent_requests: res.max_concurrent_requests
+      max_concurrent_requests: res.max_concurrent_requests,
+      api_format: res.api_format || 'openai'
     }
   } catch (e) {
     message.error(t('llm.fetch_failed'))
@@ -124,6 +144,7 @@ function applyPreset(preset: any) {
   config.value.base_url = preset.base_url
   config.value.model_name = preset.model_name
   config.value.fast_model_name = preset.fast_model_name
+  config.value.api_format = preset.api_format || 'openai'
   // Ollama doesn't require a real API key, auto-fill a placeholder.
   if ('isLocal' in preset && preset.isLocal) {
     config.value.api_key = 'ollama'
@@ -211,12 +232,35 @@ onMounted(() => {
 
         <div class="form-item">
           <label>{{ t('llm.labels.base_url') }}</label>
-          <input 
-            v-model="config.base_url" 
-            type="text" 
+          <input
+            v-model="config.base_url"
+            type="text"
             :placeholder="t('llm.placeholders.base_url')"
             class="input-field"
           />
+        </div>
+
+        <div class="form-item">
+          <label>{{ t('llm.labels.api_format') }}</label>
+          <div class="format-options">
+            <label
+              v-for="opt in apiFormatOptions"
+              :key="opt.value"
+              class="format-radio"
+              :class="{ active: config.api_format === opt.value }"
+            >
+              <input
+                type="radio"
+                v-model="config.api_format"
+                :value="opt.value"
+                class="hidden-radio"
+              />
+              <div class="radio-content">
+                <div class="radio-label">{{ opt.label }}</div>
+                <div class="radio-desc">{{ opt.desc }}</div>
+              </div>
+            </label>
+          </div>
         </div>
 
         <div class="form-item">
@@ -507,6 +551,35 @@ onMounted(() => {
   border-color: #666;
   color: #bbb;
   background: #2a2a2a;
+}
+
+.format-options {
+  display: flex;
+  flex-direction: row;
+  gap: 0.8em;
+}
+
+.format-radio {
+  flex: 1;
+  display: flex;
+  background: #222;
+  border: 1px solid #333;
+  padding: 0.6em 0.8em;
+  border-radius: 0.3em;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.format-radio:hover {
+  background: #2a2a2a;
+}
+
+.format-radio.active {
+  background: #1a2a3a;
+  border-color: #4a9eff;
 }
 
 .mode-options.horizontal {

--- a/web/src/locales/en-US/llm.json
+++ b/web/src/locales/en-US/llm.json
@@ -22,7 +22,8 @@
     "normal_model": "Normal Model (Normal)",
     "fast_model": "Fast Model (Fast)",
     "max_concurrent_requests": "Max Concurrent Requests",
-    "what_is_api": "What is API / How to get?"
+    "what_is_api": "What is API / How to get?",
+    "api_format": "API Format"
   },
   "descs": {
     "normal_model": "Used for complex logic, story generation, etc.",
@@ -44,6 +45,12 @@
     "fast": "Fast (Fast)",
     "fast_desc": "Use fast model for all tasks"
   },
+  "formats": {
+    "openai": "OpenAI Compatible",
+    "openai_desc": "Supported by most providers",
+    "anthropic": "Anthropic Native",
+    "anthropic_desc": "Direct Anthropic Claude API"
+  },
   "actions": {
     "testing": "Testing connection...",
     "test_and_save": "Test Connectivity and Save"
@@ -58,7 +65,7 @@
     "q2_gemini": "Produced by Google, top-tier comprehensive performance.",
     "q3_title": "📝 3. How to fill configuration?",
     "q3_content": "Once you have an API, you need to fill in these three core parameters. Usually, you can find them in the provider's documentation:",
-    "q3_format_note": "⚠️ Important: This game only supports OpenAI-compatible API format. Services that don't support OpenAI-compatible format cannot be used. We recommend using the presets (they are all confirmed compatible). If you want to use other services, please confirm they provide OpenAI-compatible interfaces.",
+    "q3_format_note": "⚠️ Note: This game supports both OpenAI-compatible and Anthropic native API formats. Most providers use the OpenAI-compatible format; if connecting directly to Anthropic API, select 'Anthropic Native' in the API Format option. We recommend using the presets.",
     "q3_base_url": "API Base URL: The entry point to AI, usually provided by the vendor (e.g., https://api.deepseek.com).",
     "q3_api_key": "API Key: Your identity credential, like an account password.",
     "q3_model_name": "Model Name: Tell the server which 'brain' to use, e.g., deepseek-chat or gemini-3-flash-preview.",
@@ -78,7 +85,8 @@
     "gemini": "Gemini",
     "groq": "Groq",
     "cerebras": "Cerebras",
-    "ollama": "Ollama (Local)"
+    "ollama": "Ollama (Local)",
+    "anthropic": "Anthropic"
   },
   "badges": {
     "recommended": "Rec",

--- a/web/src/locales/vi-VN/llm.json
+++ b/web/src/locales/vi-VN/llm.json
@@ -22,7 +22,8 @@
     "normal_model": "Mô Hình Thường (Normal)",
     "fast_model": "Mô Hình Nhanh (Fast)",
     "max_concurrent_requests": "Số Yêu Cầu Đồng Thời Tối Đa",
-    "what_is_api": "API là gì / Lấy ở đâu?"
+    "what_is_api": "API là gì / Lấy ở đâu?",
+    "api_format": "Định Dạng API"
   },
   "descs": {
     "normal_model": "Dùng cho logic phức tạp, tạo cốt truyện, v.v.",
@@ -44,6 +45,12 @@
     "fast": "Nhanh (Fast)",
     "fast_desc": "Dùng mô hình nhanh cho mọi tác vụ"
   },
+  "formats": {
+    "openai": "Tương thích OpenAI",
+    "openai_desc": "Hầu hết nhà cung cấp đều hỗ trợ",
+    "anthropic": "Anthropic gốc",
+    "anthropic_desc": "Kết nối trực tiếp Anthropic Claude"
+  },
   "actions": {
     "testing": "Đang kiểm tra kết nối...",
     "test_and_save": "Kiểm Tra Kết Nối Và Lưu"
@@ -58,7 +65,7 @@
     "q2_gemini": "Sản phẩm của Google, năng lực tổng hợp thuộc hàng đầu.",
     "q3_title": "📝 3. Điền cấu hình như thế nào?",
     "q3_content": "Khi đã có API, bạn cần điền ba tham số cốt lõi này. Thông thường, bạn có thể tìm thấy chúng trong tài liệu của nhà cung cấp:",
-    "q3_format_note": "⚠️ Quan trọng: Trò chơi này chỉ hỗ trợ định dạng API tương thích OpenAI. Những dịch vụ không hỗ trợ chuẩn tương thích OpenAI sẽ không dùng được. Chúng tôi khuyến nghị dùng preset có sẵn (đều đã xác nhận tương thích). Nếu muốn dùng dịch vụ khác, hãy chắc chắn rằng họ cung cấp giao diện tương thích OpenAI.",
+    "q3_format_note": "⚠️ Lưu ý: Trò chơi này hỗ trợ cả định dạng tương thích OpenAI và định dạng gốc Anthropic. Hầu hết nhà cung cấp sử dụng định dạng tương thích OpenAI; nếu kết nối trực tiếp Anthropic API, hãy chọn 'Anthropic gốc' trong tùy chọn Định dạng API. Chúng tôi khuyến nghị dùng preset có sẵn.",
     "q3_base_url": "API Base URL: cổng vào của AI, thường do nhà cung cấp đưa ra (ví dụ: https://api.deepseek.com).",
     "q3_api_key": "API Key: thông tin định danh của bạn, giống như mật khẩu tài khoản.",
     "q3_model_name": "Tên mô hình: cho máy chủ biết nên dùng \"bộ não\" nào, ví dụ deepseek-chat hoặc gemini-3-flash-preview.",
@@ -78,7 +85,8 @@
     "gemini": "Gemini",
     "groq": "Groq",
     "cerebras": "Cerebras",
-    "ollama": "Ollama (Cục bộ)"
+    "ollama": "Ollama (Cục bộ)",
+    "anthropic": "Anthropic"
   },
   "badges": {
     "recommended": "Đề cử",

--- a/web/src/locales/zh-CN/llm.json
+++ b/web/src/locales/zh-CN/llm.json
@@ -22,7 +22,8 @@
     "normal_model": "智能模型 (Normal)",
     "fast_model": "快速模型 (Fast)",
     "max_concurrent_requests": "最大并发数",
-    "what_is_api": "什么是 API / 如何获取?"
+    "what_is_api": "什么是 API / 如何获取?",
+    "api_format": "API 格式"
   },
   "descs": {
     "normal_model": "用于处理复杂逻辑、剧情生成等任务",
@@ -44,6 +45,12 @@
     "fast": "快速 (Fast)",
     "fast_desc": "全用快速模型"
   },
+  "formats": {
+    "openai": "OpenAI 兼容",
+    "openai_desc": "大多数服务商均支持",
+    "anthropic": "Anthropic 原生",
+    "anthropic_desc": "Anthropic Claude 直连"
+  },
   "actions": {
     "testing": "测试连接中...",
     "test_and_save": "测试连通性并保存"
@@ -58,7 +65,7 @@
     "q2_gemini": "Google 出品，综合性能顶尖。",
     "q3_title": "📝 3. 如何填入配置?",
     "q3_content": "获得 API 后，你需要填入以下三大核心参数才能使用，通常你可以在api提供方的文档中找到 these 参数怎么填：",
-    "q3_format_note": "⚠️ 重要提示：本游戏仅支持 OpenAI 兼容格式的 API。如果某个服务不支持 OpenAI 兼容格式，将无法使用。推荐使用预设中的服务（它们都已确认兼容）。如需使用其他服务，请确认其提供 OpenAI 兼容接口。",
+    "q3_format_note": "⚠️ 提示：本游戏支持 OpenAI 兼容格式和 Anthropic 原生格式。大多数服务商使用 OpenAI 兼容格式；如果直连 Anthropic API，请在 API 格式中选择「Anthropic 原生」。推荐使用预设中的服务。",
     "q3_base_url": "API Base URL (接口地址): AI 的访问大门，通常由厂商提供 (如 https://api.deepseek.com)。",
     "q3_api_key": "API Key (密钥): 你的身份凭证，就像账号密码。",
     "q3_model_name": "Model Name (模型名称): 告诉服务器你想用哪颗大脑，如 deepseek-chat 或 gemini-3-flash-preview。",
@@ -78,7 +85,8 @@
     "gemini": "Gemini",
     "groq": "Groq",
     "cerebras": "Cerebras",
-    "ollama": "Ollama (本地)"
+    "ollama": "Ollama (本地)",
+    "anthropic": "Anthropic"
   },
   "badges": {
     "recommended": "推荐",

--- a/web/src/locales/zh-TW/llm.json
+++ b/web/src/locales/zh-TW/llm.json
@@ -22,7 +22,8 @@
     "normal_model": "智能模型 (Normal)",
     "fast_model": "快速模型 (Fast)",
     "max_concurrent_requests": "最大並發數",
-    "what_is_api": "什麼是 API / 如何獲取?"
+    "what_is_api": "什麼是 API / 如何獲取?",
+    "api_format": "API 格式"
   },
   "descs": {
     "normal_model": "用於處理複雜邏輯、劇情生成等任務",
@@ -44,6 +45,12 @@
     "fast": "快速 (Fast)",
     "fast_desc": "全用快速模型"
   },
+  "formats": {
+    "openai": "OpenAI 兼容",
+    "openai_desc": "大多數服務商均支援",
+    "anthropic": "Anthropic 原生",
+    "anthropic_desc": "Anthropic Claude 直連"
+  },
   "actions": {
     "testing": "測試連接中...",
     "test_and_save": "測試連通性並儲存"
@@ -58,7 +65,7 @@
     "q2_gemini": "Google 出品，綜合性能頂尖。",
     "q3_title": "📝 3. 如何填入配置?",
     "q3_content": "獲得 API 後，你需要填入以下三大核心參數才能使用，通常你可以在api提供方的文檔中找到 these 參數怎麼填：",
-    "q3_format_note": "⚠️ 重要提示：本遊戲僅支持 OpenAI 兼容格式的 API。如果某個服務不支持 OpenAI 兼容格式，將無法使用。推薦使用預設中的服務（它們都已確認兼容）。如需使用其他服務，請確認其提供 OpenAI 兼容接口。",
+    "q3_format_note": "⚠️ 提示：本遊戲支援 OpenAI 兼容格式和 Anthropic 原生格式。大多數服務商使用 OpenAI 兼容格式；如果直連 Anthropic API，請在 API 格式中選擇「Anthropic 原生」。推薦使用預設中的服務。",
     "q3_base_url": "API Base URL (接口地址): AI 的訪問大門，通常由廠商提供 (如 https://api.deepseek.com)。",
     "q3_api_key": "API Key (密鑰): 你的身份憑證，就像賬號密碼。",
     "q3_model_name": "Model Name (模型名稱): 告訴服務器你想用哪顆大腦，如 deepseek-chat 或 gemini-3-flash-preview。",
@@ -78,7 +85,8 @@
     "gemini": "Gemini",
     "groq": "Groq",
     "cerebras": "Cerebras",
-    "ollama": "Ollama (本地)"
+    "ollama": "Ollama (本地)",
+    "anthropic": "Anthropic"
   },
   "badges": {
     "recommended": "推薦",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -172,6 +172,7 @@ export interface LLMConfigViewDTO {
   mode: string;
   max_concurrent_requests: number;
   has_api_key: boolean;
+  api_format: string;
 }
 
 export interface LLMConfigDTO {
@@ -182,6 +183,7 @@ export interface LLMConfigDTO {
   mode: string;
   max_concurrent_requests: number;
   clear_api_key?: boolean;
+  api_format: string;
 }
 
 export interface RunConfigDTO {


### PR DESCRIPTION
## 背景

我是一个非程序员玩家，在使用过程中发现 LLM 配置只支持 OpenAI 兼容格式，缺少 Anthropic 原生 API 的支持。于是通过 vibe coding 的方式补充了这个配置选项。自己测试了一下是可以正常使用的，提交给作者看看是否合适合入。

## 改动内容

- 在 LLM 设置面板的 API 配置区域新增了一个 **API 格式** 选择器，支持 **OpenAI 兼容** 和 **Anthropic 原生** 两种格式
- 新增 **Anthropic** 预设（Claude Sonnet 4 / Haiku 4），点击即可自动填充
- 后端新增 `_call_anthropic()` 调用实现，使用 Anthropic 原生的 `x-api-key` 认证头、`/v1/messages` 端点和响应解析
- 顺带把 HTTP 调用从 `urllib` 换成了 `requests` 库，解决了部分代理环境下的 SSL 兼容性问题
- 四种语言的 i18n 都补充了（zh-CN、zh-TW、en-US、vi-VN）

## 向后兼容

- `api_format` 默认值为 `"openai"`，现有用户的配置不受任何影响
- 旧版前端不传 `api_format` 字段时，后端自动按 OpenAI 格式处理

## 我的测试情况

- [x] Anthropic 格式连通性测试通过
- [x] OpenAI 格式连通性测试通过
- [x] 配置保存/读取/持久化正常
- [x] 错误处理正常（假 key 会返回友好提示）
- [x] 不传 api_format 时向后兼容
- [x] TypeScript 类型检查通过
- [x] 前端构建通过