### PR TITLE
feat: 已故角色独立存档与管理

### DIFF
--- a/src/classes/core/world.py
+++ b/src/classes/core/world.py
@@ -7,6 +7,7 @@ from src.classes.environment.map import Map
 from src.systems.time import Year, Month, MonthStamp
 from src.sim.managers.avatar_manager import AvatarManager
 from src.sim.managers.mortal_manager import MortalManager
+from src.sim.managers.deceased_manager import DeceasedManager
 from src.sim.managers.event_manager import EventManager
 from src.classes.circulation import CirculationManager
 from src.classes.gathering.gathering import GatheringManager
@@ -33,6 +34,8 @@ class World():
     mortal_manager: MortalManager = field(default_factory=MortalManager)
     # 全局事件管理器
     event_manager: EventManager = field(default_factory=EventManager)
+    # 已故角色档案管理器（独立于 AvatarManager，不受 cleanup 影响）
+    deceased_manager: DeceasedManager = field(default_factory=DeceasedManager)
     # 当前天地灵机（世界级buff/debuff）
     current_phenomenon: Optional["CelestialPhenomenon"] = None
     # 当前王朝（凡人王朝）

--- a/src/classes/death.py
+++ b/src/classes/death.py
@@ -23,5 +23,8 @@ def handle_death(world: World, avatar: Avatar, reason: Union[str, DeathReason]) 
     
     # 从管理器中归档（硬移动），并记录变更
     world.avatar_manager.handle_death(avatar.id)
+
+    # 记录已故档案（独立于 AvatarManager，不受 cleanup 影响）
+    world.deceased_manager.record_death(avatar)
     
     # 可以在这里触发其他逻辑，比如检查是否有继承人等

--- a/src/classes/deceased_record.py
+++ b/src/classes/deceased_record.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DeceasedRecord:
+    """已故角色轻量档案，独立于 Avatar 对象，不受 cleanup_long_dead_avatars 影响。"""
+
+    id: str
+    name: str
+    gender: str
+    age_at_death: int
+    realm_at_death: str       # cultivation_progress.realm.value
+    stage_at_death: str       # cultivation_progress.stage.value
+    death_reason: str
+    death_time: int            # MonthStamp int, 与 death_info["time"] 同语义
+    sect_name_at_death: str    # avatar.sect.name if avatar.sect else ""
+    alignment_at_death: str    # avatar.alignment.value if avatar.alignment else ""
+    backstory: Optional[str] = None
+    custom_pic_id: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "gender": self.gender,
+            "age_at_death": self.age_at_death,
+            "realm_at_death": self.realm_at_death,
+            "stage_at_death": self.stage_at_death,
+            "death_reason": self.death_reason,
+            "death_time": self.death_time,
+            "sect_name_at_death": self.sect_name_at_death,
+            "alignment_at_death": self.alignment_at_death,
+            "backstory": self.backstory,
+            "custom_pic_id": self.custom_pic_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DeceasedRecord":
+        fields = cls.__dataclass_fields__
+        filtered = {k: data[k] for k in fields if k in data}
+        return cls(**filtered)

--- a/src/server/api/public_v1/query.py
+++ b/src/server/api/public_v1/query.py
@@ -27,6 +27,7 @@ def create_public_query_router(
     build_dynasty_detail: Callable[[], dict],
     build_saves: Callable[[], dict],
     build_detail: Callable[..., dict],
+    build_deceased_list: Callable[[], dict],
 ) -> APIRouter:
     router = APIRouter()
 
@@ -122,5 +123,9 @@ def create_public_query_router(
         target_id: str = Query(alias="id"),
     ):
         return ok_response(build_detail(target_type=target_type, target_id=target_id))
+
+    @router.get("/api/v1/query/deceased")
+    def get_deceased_list_v1():
+        return ok_response(build_deceased_list())
 
     return router

--- a/src/server/host_app.py
+++ b/src/server/host_app.py
@@ -118,6 +118,7 @@ def configure_routes_and_mounts(
     build_dynasty_detail,
     build_saves,
     build_detail,
+    build_deceased_list,
     create_public_command_router,
     run_start_game,
     run_reinit_game,
@@ -179,6 +180,7 @@ def configure_routes_and_mounts(
             build_dynasty_detail=build_dynasty_detail,
             build_saves=build_saves,
             build_detail=build_detail,
+            build_deceased_list=build_deceased_list,
         )
     )
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -54,6 +54,7 @@ from src.server.services.custom_goldfinger_service import (
 from src.server.services.game_lifecycle import reinit_game_lifecycle, start_game_lifecycle
 from src.server.services.game_queries import (
     get_detail as get_detail_query,
+    get_deceased_list,
     get_events_page,
     get_game_data as get_game_data_query,
     get_rankings as get_rankings_query,
@@ -271,6 +272,7 @@ public_query_builders = create_public_query_builders(
     build_dynasty_overview=build_dynasty_overview,
     get_dynasty_detail_query=get_dynasty_detail_query,
     build_dynasty_detail=build_dynasty_detail,
+    get_deceased_list_query=get_deceased_list,
 )
 
 build_public_world_state = public_query_builders.build_public_world_state
@@ -291,6 +293,7 @@ build_public_sect_relations = public_query_builders.build_public_sect_relations
 build_public_mortal_overview = public_query_builders.build_public_mortal_overview
 build_public_dynasty_overview = public_query_builders.build_public_dynasty_overview
 build_public_dynasty_detail = public_query_builders.build_public_dynasty_detail
+build_public_deceased_list = public_query_builders.build_public_deceased_list
 
 
 def update_init_progress(phase: int, phase_name: str = ""):
@@ -541,6 +544,7 @@ configure_routes_and_mounts(
     build_dynasty_detail=build_public_dynasty_detail,
     build_saves=build_public_saves,
     build_detail=build_public_detail,
+    build_deceased_list=build_public_deceased_list,
     create_public_command_router=create_public_command_router,
     run_start_game=run_start_game,
     run_reinit_game=run_reinit_game,

--- a/src/server/public_query_builders.py
+++ b/src/server/public_query_builders.py
@@ -47,6 +47,7 @@ def create_public_query_builders(
     build_dynasty_overview,
     get_dynasty_detail_query,
     build_dynasty_detail,
+    get_deceased_list_query,
 ):
     def _resolve_avatar_pic_id(avatar):
         return resolve_avatar_pic_id(avatar_assets=avatar_assets, avatar=avatar)
@@ -157,6 +158,9 @@ def create_public_query_builders(
     def build_public_dynasty_detail() -> dict:
         return get_dynasty_detail_query(runtime, build_dynasty_detail=build_dynasty_detail)
 
+    def build_public_deceased_list() -> dict:
+        return get_deceased_list_query(runtime)
+
     return SimpleNamespace(
         build_public_world_state=build_public_world_state,
         build_public_world_map=build_public_world_map,
@@ -176,4 +180,5 @@ def create_public_query_builders(
         build_public_mortal_overview=build_public_mortal_overview,
         build_public_dynasty_overview=build_public_dynasty_overview,
         build_public_dynasty_detail=build_public_dynasty_detail,
+        build_public_deceased_list=build_public_deceased_list,
     )

--- a/src/server/services/game_queries.py
+++ b/src/server/services/game_queries.py
@@ -221,6 +221,13 @@ def _require_world(runtime):
     return world
 
 
+def get_deceased_list(runtime) -> dict[str, Any]:
+    """返回所有已故角色档案列表。"""
+    world = _require_world(runtime)
+    records = world.deceased_manager.get_all_records()
+    return {"deceased": [r.to_dict() for r in records]}
+
+
 def get_world_state(
     runtime,
     *,

--- a/src/sim/load/load_game.py
+++ b/src/sim/load/load_game.py
@@ -152,6 +152,10 @@ def load_game(save_path: Optional[Path] = None) -> Tuple["World", "Simulator", L
         world.prune_expired_sect_relation_modifiers(int(world.month_stamp))
         world.sect_wars = list(world_data.get("sect_wars", []) or [])
 
+        # 恢复已故角色档案
+        deceased_data = world_data.get("deceased_records", [])
+        world.deceased_manager.load_from_list(deceased_data)
+
         for sect in sects_by_id.values():
             sect.magic_stone = 0
             sect.is_active = True

--- a/src/sim/managers/deceased_manager.py
+++ b/src/sim/managers/deceased_manager.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.classes.core.avatar import Avatar
+
+from src.classes.deceased_record import DeceasedRecord
+
+
+@dataclass
+class DeceasedManager:
+    """已故角色档案管理器，独立于 AvatarManager，不受 cleanup_long_dead_avatars 影响。"""
+
+    _records: Dict[str, DeceasedRecord] = field(default_factory=dict)
+
+    def record_death(self, avatar: "Avatar") -> None:
+        """从 Avatar 快照生成 DeceasedRecord，按 id 覆盖写入（幂等）。"""
+        death_info = avatar.death_info or {}
+        record = DeceasedRecord(
+            id=avatar.id,
+            name=avatar.name,
+            gender=avatar.gender.value if hasattr(avatar.gender, "value") else str(avatar.gender),
+            age_at_death=avatar.age.age,
+            realm_at_death=avatar.cultivation_progress.realm.value,
+            stage_at_death=avatar.cultivation_progress.stage.value,
+            death_reason=death_info.get("reason", ""),
+            death_time=death_info.get("time", 0),
+            sect_name_at_death=avatar.sect.name if avatar.sect else "",
+            alignment_at_death=str(avatar.alignment) if avatar.alignment else "",
+            backstory=avatar.backstory,
+            custom_pic_id=avatar.custom_pic_id,
+        )
+        self._records[avatar.id] = record
+
+    def get_all_records(self) -> List[DeceasedRecord]:
+        """按死亡时间倒序返回所有记录。"""
+        return sorted(self._records.values(), key=lambda r: r.death_time, reverse=True)
+
+    def get_record(self, avatar_id: str) -> Optional[DeceasedRecord]:
+        return self._records.get(avatar_id)
+
+    def to_save_list(self) -> List[dict]:
+        return [r.to_dict() for r in self._records.values()]
+
+    def load_from_list(self, data: List[dict]) -> None:
+        self._records.clear()
+        for item in data:
+            record = DeceasedRecord.from_dict(item)
+            self._records[record.id] = record

--- a/src/sim/save/save_game.py
+++ b/src/sim/save/save_game.py
@@ -210,6 +210,8 @@ def save_game(
             "sect_runtime_states": sect_runtime_states,
             "sect_relation_modifiers": list(getattr(world, "sect_relation_modifiers", []) or []),
             "sect_wars": list(getattr(world, "sect_wars", []) or []),
+            # 已故角色档案（独立于 AvatarManager，不受 cleanup 影响）
+            "deceased_records": world.deceased_manager.to_save_list(),
         }
         
         # 保存所有Avatar（第一阶段：不含relations）

--- a/tests/test_deceased_manager.py
+++ b/tests/test_deceased_manager.py
@@ -1,0 +1,168 @@
+"""DeceasedManager 单测 + 存读档 + 清理不影响 + 幂等性"""
+import pytest
+from src.sim.save.save_game import save_game
+from src.sim.load.load_game import load_game
+from src.classes.death import handle_death
+from src.classes.death_reason import DeathReason, DeathType
+from src.systems.time import MonthStamp, Month, Year, create_month_stamp
+
+
+def test_record_death_creates_record(base_world, dummy_avatar):
+    """死亡后 DeceasedManager 中有对应记录，字段值正确。"""
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+    death_time = int(base_world.month_stamp)
+    dummy_avatar.set_dead("Test Death", death_time)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    record = base_world.deceased_manager.get_record(dummy_avatar.id)
+    assert record is not None
+    assert record.name == dummy_avatar.name
+    assert record.realm_at_death == dummy_avatar.cultivation_progress.realm.value
+    assert record.stage_at_death == dummy_avatar.cultivation_progress.stage.value
+    assert record.death_reason == "Test Death"
+    assert record.death_time == death_time
+    assert record.gender == dummy_avatar.gender.value
+    assert record.alignment_at_death == str(dummy_avatar.alignment)
+
+
+def test_record_death_is_idempotent(base_world, dummy_avatar):
+    """重复调用 record_death 不会产生重复记录。"""
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+    death_time = int(base_world.month_stamp)
+    dummy_avatar.set_dead("Test", death_time)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+
+    base_world.deceased_manager.record_death(dummy_avatar)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    records = base_world.deceased_manager.get_all_records()
+    count = sum(1 for r in records if r.id == dummy_avatar.id)
+    assert count == 1
+
+
+def test_get_all_records_sorted_by_death_time_desc(base_world, dummy_avatar):
+    """记录按死亡时间倒序排列。"""
+    from src.classes.core.avatar import Avatar, Gender
+    from src.classes.age import Age
+    from src.classes.root import Root
+    from src.classes.alignment import Alignment
+    from src.systems.cultivation import Realm
+    from src.utils.id_generator import get_avatar_id
+
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+
+    # 创建第二个角色
+    avatar2 = Avatar(
+        world=base_world,
+        name="Second",
+        id=get_avatar_id(),
+        birth_month_stamp=create_month_stamp(Year(2000), Month.JANUARY),
+        age=Age(30, Realm.Qi_Refinement, innate_max_lifespan=80),
+        gender=Gender.FEMALE,
+        pos_x=1,
+        pos_y=1,
+        root=Root.WATER,
+        personas=[],
+        alignment=Alignment.EVIL,
+    )
+    avatar2.personas = []
+    avatar2.weapon = None
+    base_world.avatar_manager.register_avatar(avatar2)
+
+    # 第一个角色先死
+    dummy_avatar.set_dead("First Death", 100)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    # 第二个角色后死
+    avatar2.set_dead("Second Death", 200)
+    base_world.avatar_manager.handle_death(avatar2.id)
+    base_world.deceased_manager.record_death(avatar2)
+
+    records = base_world.deceased_manager.get_all_records()
+    assert len(records) == 2
+    assert records[0].death_time > records[1].death_time
+
+
+def test_to_save_list_and_load_from_list_roundtrip(base_world, dummy_avatar):
+    """序列化/反序列化往返测试。"""
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+    death_time = int(base_world.month_stamp)
+    dummy_avatar.set_dead("Round Trip", death_time)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    save_list = base_world.deceased_manager.to_save_list()
+    assert len(save_list) == 1
+
+    # 重建一个新 manager 并加载
+    from src.sim.managers.deceased_manager import DeceasedManager
+    new_manager = DeceasedManager()
+    new_manager.load_from_list(save_list)
+
+    loaded = new_manager.get_record(dummy_avatar.id)
+    assert loaded is not None
+    assert loaded.name == dummy_avatar.name
+    assert loaded.realm_at_death == dummy_avatar.cultivation_progress.realm.value
+    assert loaded.stage_at_death == dummy_avatar.cultivation_progress.stage.value
+    assert loaded.death_reason == "Round Trip"
+    assert loaded.death_time == death_time
+
+
+def test_deceased_records_survive_cleanup(base_world, dummy_avatar):
+    """核心业务承诺：cleanup_long_dead_avatars 后 deceased_manager 记录仍在。"""
+    death_time = create_month_stamp(Year(1), Month.JANUARY)
+    dummy_avatar.set_dead("Old Age", death_time)
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    # 模拟 20 年后清理
+    current_time = create_month_stamp(Year(21), Month.JANUARY)
+    base_world.avatar_manager.cleanup_long_dead_avatars(current_time, threshold_years=20)
+
+    # Avatar 对象已被清理
+    assert base_world.avatar_manager.get_avatar(dummy_avatar.id) is None
+    # 但 DeceasedManager 记录仍在
+    assert base_world.deceased_manager.get_record(dummy_avatar.id) is not None
+    assert base_world.deceased_manager.get_record(dummy_avatar.id).name == dummy_avatar.name
+
+
+def test_deceased_records_survive_save_load(base_world, dummy_avatar):
+    """存档/读档后 deceased_records 恢复完整。"""
+    dummy_avatar.weapon = None
+    base_world.avatar_manager.register_avatar(dummy_avatar)
+
+    # 杀死角色
+    death_time = int(base_world.month_stamp)
+    dummy_avatar.set_dead("Save Load Test", death_time)
+    base_world.avatar_manager.handle_death(dummy_avatar.id)
+    base_world.deceased_manager.record_death(dummy_avatar)
+
+    # 保存
+    from src.sim.simulator import Simulator
+    simulator = Simulator(base_world)
+    success, save_filename = save_game(base_world, simulator, existed_sects=[])
+    assert success
+
+    from src.utils.config import CONFIG
+    save_path = CONFIG.paths.saves / save_filename
+
+    # 读取
+    loaded_world, loaded_sim, _ = load_game(save_path)
+
+    # 验证已故记录恢复
+    record = loaded_world.deceased_manager.get_record(dummy_avatar.id)
+    assert record is not None
+    assert record.name == dummy_avatar.name
+    assert record.death_reason == "Save Load Test"
+    assert record.death_time == death_time
+
+
+def test_empty_deceased_manager_returns_empty_list():
+    """空 manager 返回空列表。"""
+    from src.sim.managers.deceased_manager import DeceasedManager
+    manager = DeceasedManager()
+    assert manager.get_all_records() == []
+    assert manager.to_save_list() == []

--- a/tests/test_public_api_v1.py
+++ b/tests/test_public_api_v1.py
@@ -579,3 +579,39 @@ def test_v1_create_custom_content_uses_ok_envelope():
     finally:
         main.game_instance.clear()
         main.game_instance.update(original)
+
+
+def test_v1_deceased_list_returns_ok_envelope_when_world_missing():
+    """GET /api/v1/query/deceased 在世界未初始化时返回 503。"""
+    original = _reset_state()
+    try:
+        client = TestClient(main.app)
+        response = client.get("/api/v1/query/deceased")
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert detail["code"] == "WORLD_NOT_READY"
+    finally:
+        main.game_instance.clear()
+        main.game_instance.update(original)
+
+
+def test_v1_deceased_list_returns_ok_with_world():
+    """GET /api/v1/query/deceased 在世界初始化后返回 ok + deceased 列表。"""
+    original = _reset_state()
+    try:
+        mock_world = MagicMock()
+        mock_world.deceased_manager.get_all_records.return_value = []
+        main.game_instance["world"] = mock_world
+
+        client = TestClient(main.app)
+        response = client.get("/api/v1/query/deceased")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["ok"] is True
+        assert "deceased" in payload["data"]
+        assert isinstance(payload["data"]["deceased"], list)
+    finally:
+        main.game_instance.clear()
+        main.game_instance.update(original)

--- a/web/src/__tests__/components/StatusBar.test.ts
+++ b/web/src/__tests__/components/StatusBar.test.ts
@@ -157,6 +157,7 @@ describe('StatusBar', () => {
       stubs: {
         StatusWidget: StatusWidgetStub,
         TimeOverviewModal: true,
+        DeceasedModal: true,
       },
     },
   }
@@ -268,9 +269,9 @@ describe('StatusBar', () => {
 
       const wrapper = mount(StatusBar, globalConfig)
 
-      // time + world info + domain/ranking/tournament/sect-relations/mortal/dynasty
+      // time + world info + domain/ranking/tournament/sect-relations/mortal/dynasty/deceased
       const widgets = wrapper.findAll('.status-widget-stub')
-      expect(widgets.length).toBe(8)
+      expect(widgets.length).toBe(9)
     })
 
     it('should place time widget before world info widget and phenomenon widget', () => {
@@ -432,8 +433,8 @@ describe('StatusBar', () => {
     const wrapper = mount(StatusBar, globalConfig)
 
     const widgets = wrapper.findAll('.status-widget-stub')
-    // time + worldInfo + currentPhenomenon + domain + ranking + tournament + sect_relations + mortal + dynasty
-    expect(widgets.length).toBe(9)
+    // time + worldInfo + currentPhenomenon + domain + ranking + tournament + sect_relations + mortal + dynasty + deceased
+    expect(widgets.length).toBe(10)
     const sectRelationsWidget = widgets[6]
     expect(sectRelationsWidget.attributes('data-label')).toBe('game.sect_relations.title_short')
   })
@@ -444,5 +445,14 @@ describe('StatusBar', () => {
     const widgets = wrapper.findAll('.status-widget-stub')
     const dynastyWidget = widgets[8]
     expect(dynastyWidget.attributes('data-label')).toBe('game.dynasty.title_short')
+  })
+
+  it('should render deceased StatusWidget', () => {
+    const wrapper = mount(StatusBar, globalConfig)
+
+    const widgets = wrapper.findAll('.status-widget-stub')
+    const deceasedWidget = widgets[9]
+    expect(deceasedWidget.attributes('data-label')).toBe('game.deceased.title_short')
+    expect(deceasedWidget.attributes('data-color')).toBe('#8c8c8c')
   })
 })

--- a/web/src/api/mappers/deceased.ts
+++ b/web/src/api/mappers/deceased.ts
@@ -1,0 +1,39 @@
+import type { DeceasedRecordDTO } from '@/types/api'
+
+export interface DeceasedRecordView {
+  id: string
+  name: string
+  gender: string
+  ageAtDeath: number
+  realmDisplay: string
+  stageDisplay: string
+  deathReason: string
+  deathYear: number
+  deathMonth: number
+  sectName: string
+  alignment: string
+  backstory: string | null
+  customPicId: number | null
+}
+
+export function mapDeceasedRecord(dto: DeceasedRecordDTO): DeceasedRecordView {
+  return {
+    id: dto.id,
+    name: dto.name,
+    gender: dto.gender,
+    ageAtDeath: dto.age_at_death,
+    realmDisplay: dto.realm_at_death,
+    stageDisplay: dto.stage_at_death,
+    deathReason: dto.death_reason,
+    deathYear: Math.floor(dto.death_time / 12) + 1,
+    deathMonth: (dto.death_time % 12) + 1,
+    sectName: dto.sect_name_at_death,
+    alignment: dto.alignment_at_death,
+    backstory: dto.backstory,
+    customPicId: dto.custom_pic_id,
+  }
+}
+
+export function mapDeceasedList(dtos: DeceasedRecordDTO[]): DeceasedRecordView[] {
+  return dtos.map(mapDeceasedRecord)
+}

--- a/web/src/api/modules/world.ts
+++ b/web/src/api/modules/world.ts
@@ -9,6 +9,7 @@ import type {
   MortalOverviewResponseDTO,
   DynastyDetailResponseDTO,
   DynastyOverviewResponseDTO,
+  DeceasedListResponseDTO,
 } from '../../types/api';
 import {
   normalizeInitialState,
@@ -65,5 +66,10 @@ export const worldApi = {
   async fetchDynastyDetail() {
     const data = await httpClient.get<DynastyDetailResponseDTO>('/api/v1/query/dynasty/detail');
     return normalizeDynastyDetail(data);
+  },
+
+  async fetchDeceasedList() {
+    const data = await httpClient.get<DeceasedListResponseDTO>('/api/v1/query/deceased');
+    return data.deceased;
   },
 };

--- a/web/src/components/game/panels/DeceasedModal.vue
+++ b/web/src/components/game/panels/DeceasedModal.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import { ref, shallowRef, watch } from 'vue'
+import { NModal, NTable, NSpin, NEmpty, NButton } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { worldApi } from '../../../api/modules/world'
+import { eventApi } from '../../../api/modules/event'
+import { mapDeceasedList } from '../../../api/mappers/deceased'
+import type { DeceasedRecordView } from '../../../api/mappers/deceased'
+import type { EventDTO } from '@/types/api'
+import { formatRealmStage } from '@/utils/cultivationText'
+import { logError } from '@/utils/appError'
+
+const props = defineProps<{
+  show: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:show', value: boolean): void
+}>()
+
+const { t } = useI18n()
+
+const loading = ref(false)
+const records = shallowRef<DeceasedRecordView[]>([])
+const selectedRecord = ref<DeceasedRecordView | null>(null)
+const eventsLoading = ref(false)
+const events = shallowRef<EventDTO[]>([])
+
+const fetchDeceased = async () => {
+  loading.value = true
+  try {
+    const dtos = await worldApi.fetchDeceasedList()
+    records.value = mapDeceasedList(dtos)
+  } catch (e) {
+    logError('DeceasedModal fetch deceased', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+const fetchEvents = async (avatarId: string) => {
+  eventsLoading.value = true
+  try {
+    const res = await eventApi.fetchEvents({ avatar_id: avatarId, limit: 50 })
+    events.value = res.events
+  } catch (e) {
+    logError('DeceasedModal fetch events', e)
+  } finally {
+    eventsLoading.value = false
+  }
+}
+
+const selectRecord = (record: DeceasedRecordView) => {
+  selectedRecord.value = record
+  events.value = []
+  fetchEvents(record.id)
+}
+
+const backToList = () => {
+  selectedRecord.value = null
+  events.value = []
+}
+
+const handleShowChange = (val: boolean) => {
+  emit('update:show', val)
+}
+
+watch(() => props.show, (newVal) => {
+  if (newVal) {
+    selectedRecord.value = null
+    events.value = []
+    fetchDeceased()
+  }
+})
+</script>
+
+<template>
+  <n-modal
+    :show="show"
+    @update:show="handleShowChange"
+    preset="card"
+    :title="t('game.deceased.title')"
+    style="width: 700px; max-height: 80vh; overflow-y: auto;"
+  >
+    <!-- 详情视图 -->
+    <template v-if="selectedRecord">
+      <div style="margin-bottom: 12px;">
+        <n-button size="small" @click="backToList">{{ t('game.deceased.back_to_list') }}</n-button>
+      </div>
+
+      <div class="deceased-detail-card">
+        <div class="detail-row">
+          <span class="detail-label">{{ t('game.deceased.age_at_death') }}</span>
+          <span>{{ selectedRecord.ageAtDeath }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">{{ t('game.deceased.realm_at_death') }}</span>
+          <span>{{ formatRealmStage(selectedRecord.realmDisplay, selectedRecord.stageDisplay, t) }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">{{ t('game.deceased.death_reason') }}</span>
+          <span>{{ selectedRecord.deathReason }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">{{ t('game.deceased.death_time') }}</span>
+          <span>{{ t('game.deceased.death_year', { year: selectedRecord.deathYear, month: selectedRecord.deathMonth }) }}</span>
+        </div>
+        <div class="detail-row" v-if="selectedRecord.sectName">
+          <span class="detail-label">{{ t('game.deceased.sect') }}</span>
+          <span>{{ selectedRecord.sectName }}</span>
+        </div>
+        <div class="detail-row" v-if="selectedRecord.alignment">
+          <span class="detail-label">{{ t('game.deceased.alignment') }}</span>
+          <span>{{ selectedRecord.alignment }}</span>
+        </div>
+        <div class="detail-row" v-if="selectedRecord.backstory">
+          <span class="detail-label">{{ t('game.deceased.backstory') }}</span>
+          <span>{{ selectedRecord.backstory }}</span>
+        </div>
+      </div>
+
+      <h4 style="margin: 16px 0 8px;">{{ t('game.deceased.events') }}</h4>
+      <n-spin :show="eventsLoading">
+        <div v-if="events.length === 0 && !eventsLoading" style="text-align: center; color: #888; padding: 16px;">
+          {{ t('game.deceased.no_events') }}
+        </div>
+        <div v-else class="event-list">
+          <div v-for="evt in events" :key="evt.id" class="event-item">
+            <span class="event-time">[{{ evt.year }}-{{ evt.month }}]</span>
+            <span class="event-text">{{ evt.content }}</span>
+          </div>
+        </div>
+      </n-spin>
+    </template>
+
+    <!-- 列表视图 -->
+    <template v-else>
+      <n-spin :show="loading">
+        <n-empty v-if="!loading && records.length === 0" :description="t('game.deceased.empty')" />
+        <n-table v-else :bordered="false" :single-line="false" size="small" striped>
+          <thead>
+            <tr>
+              <th>{{ t('game.deceased.name') }}</th>
+              <th>{{ t('game.deceased.sect') }}</th>
+              <th>{{ t('game.deceased.realm_at_death') }}</th>
+              <th>{{ t('game.deceased.age_at_death') }}</th>
+              <th>{{ t('game.deceased.death_reason') }}</th>
+              <th>{{ t('game.deceased.death_time') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="record in records"
+              :key="record.id"
+              class="clickable-row"
+              @click="selectRecord(record)"
+            >
+              <td>{{ record.name }}</td>
+              <td>{{ record.sectName || t('game.deceased.rogue') }}</td>
+              <td>{{ formatRealmStage(record.realmDisplay, record.stageDisplay, t) }}</td>
+              <td>{{ record.ageAtDeath }}</td>
+              <td>{{ record.deathReason }}</td>
+              <td>{{ t('game.deceased.death_year', { year: record.deathYear, month: record.deathMonth }) }}</td>
+            </tr>
+          </tbody>
+        </n-table>
+      </n-spin>
+    </template>
+  </n-modal>
+</template>
+
+<style scoped>
+.clickable-row {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+.clickable-row:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.deceased-detail-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.detail-row {
+  display: flex;
+  gap: 12px;
+}
+.detail-label {
+  color: #888;
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.event-item {
+  font-size: 13px;
+  line-height: 1.5;
+}
+.event-time {
+  color: #888;
+  margin-right: 6px;
+}
+.event-text {
+  color: #ccc;
+}
+
+:deep(.n-table) {
+  background-color: transparent;
+}
+:deep(.n-table th) {
+  font-weight: bold;
+}
+</style>

--- a/web/src/components/layout/StatusBar.vue
+++ b/web/src/components/layout/StatusBar.vue
@@ -14,6 +14,7 @@ import HiddenDomainOverviewModal from '../game/panels/HiddenDomainOverviewModal.
 import WorldInfoModal from '../game/panels/WorldInfoModal.vue'
 import TimeOverviewModal from '../game/panels/TimeOverviewModal.vue'
 import PhenomenonSelectorModal from '../game/panels/PhenomenonSelectorModal.vue'
+import DeceasedModal from '../game/panels/DeceasedModal.vue'
 import { PHENOMENON_RARITY_COLORS, STATUS_BAR_COLORS } from '@/constants/uiColors'
 import calendarIcon from '@/assets/icons/ui/lucide/calendar.svg'
 import bookOpenIcon from '@/assets/icons/ui/lucide/book-open.svg'
@@ -23,6 +24,7 @@ import trophyIcon from '@/assets/icons/ui/lucide/trophy.svg'
 import swordsIcon from '@/assets/icons/ui/lucide/swords.svg'
 import usersIcon from '@/assets/icons/ui/lucide/users.svg'
 import landmarkIcon from '@/assets/icons/ui/lucide/landmark.svg'
+import clock3Icon from '@/assets/icons/ui/lucide/clock-3.svg'
 
 const { t, locale } = useI18n()
 const store = useWorldStore()
@@ -36,6 +38,7 @@ const showSectRelationsModal = ref(false)
 const showMortalOverviewModal = ref(false)
 const showDynastyOverviewModal = ref(false)
 const showHiddenDomainModal = ref(false)
+const showDeceasedModal = ref(false)
 
 const phenomenonColor = computed(() => {
   const p = store.currentPhenomenon
@@ -144,6 +147,14 @@ async function openPhenomenonSelector() {
         :disable-popover="true"
         @trigger-click="showDynastyOverviewModal = true"
       />
+
+      <StatusWidget
+        :label="t('game.deceased.title_short')"
+        :icon="clock3Icon"
+        :color="STATUS_BAR_COLORS.neutral"
+        :disable-popover="true"
+        @trigger-click="showDeceasedModal = true"
+      />
     </div>
 
     <RankingModal v-model:show="showRankingModal" />
@@ -160,6 +171,7 @@ async function openPhenomenonSelector() {
 
     <DynastyOverviewModal v-model:show="showDynastyOverviewModal" />
     <PhenomenonSelectorModal v-model:show="showSelector" />
+    <DeceasedModal v-model:show="showDeceasedModal" />
 
     <div class="author">
       <a

--- a/web/src/locales/en-US/game.json
+++ b/web/src/locales/en-US/game.json
@@ -434,5 +434,23 @@
       "runtime_effect_meta": "Source: {source} - Remaining: {months} months",
       "runtime_effect_meta_permanent": "Source: {source} - Duration: Permanent"
     }
+  },
+  "deceased": {
+    "title_short": "Deceased",
+    "title": "Deceased Characters",
+    "empty": "No deceased characters yet",
+    "name": "Name",
+    "sect": "Sect",
+    "alignment": "Alignment",
+    "death_time": "Time of Death",
+    "death_reason": "Cause of Death",
+    "age_at_death": "Age at Death",
+    "realm_at_death": "Final Realm",
+    "backstory": "Biography",
+    "events": "Related Events",
+    "no_events": "No related events",
+    "back_to_list": "Back to List",
+    "death_year": "Year {year}, Month {month}",
+    "rogue": "Rogue"
   }
 }

--- a/web/src/locales/ja-JP/game.json
+++ b/web/src/locales/ja-JP/game.json
@@ -434,5 +434,23 @@
       "runtime_effect_meta": "出典: {source} - 残り {months} か月",
       "runtime_effect_meta_permanent": "出典: {source} - 持続: 永続"
     }
+  },
+  "deceased": {
+    "title_short": "故人",
+    "title": "故人キャラクター",
+    "empty": "故人はまだいません",
+    "name": "名前",
+    "sect": "宗門",
+    "alignment": "属性",
+    "death_time": "没年",
+    "death_reason": "死因",
+    "age_at_death": "享年",
+    "realm_at_death": "最終境界",
+    "backstory": "略歴",
+    "events": "関連イベント",
+    "no_events": "関連イベントなし",
+    "back_to_list": "リストに戻る",
+    "death_year": "第{year}年{month}月",
+    "rogue": "野修"
   }
 }

--- a/web/src/locales/vi-VN/game.json
+++ b/web/src/locales/vi-VN/game.json
@@ -434,5 +434,23 @@
       "runtime_effect_meta": "Nguồn: {source} - Còn lại: {months} tháng",
       "runtime_effect_meta_permanent": "Nguồn: {source} - Thời hạn: Vĩnh viễn"
     }
+  },
+  "deceased": {
+    "title_short": "Đã mất",
+    "title": "Nhân vật đã mất",
+    "empty": "Chưa có nhân vật đã mất",
+    "name": "Tên",
+    "sect": "Tông môn",
+    "alignment": "Phe phái",
+    "death_time": "Thời điểm qua đời",
+    "death_reason": "Nguyên nhân qua đời",
+    "age_at_death": "Thọ",
+    "realm_at_death": "Cảnh giới cuối",
+    "backstory": "Tiểu sử",
+    "events": "Sự kiện liên quan",
+    "no_events": "Không có sự kiện liên quan",
+    "back_to_list": "Quay lại danh sách",
+    "death_year": "Năm {year} tháng {month}",
+    "rogue": "Tán tu"
   }
 }

--- a/web/src/locales/zh-CN/game.json
+++ b/web/src/locales/zh-CN/game.json
@@ -434,5 +434,23 @@
       "runtime_effect_meta": "来源：{source} - 剩余：{months}个月",
       "runtime_effect_meta_permanent": "来源：{source} - 持续：长期"
     }
+  },
+  "deceased": {
+    "title_short": "已故",
+    "title": "已故角色",
+    "empty": "暂无已故角色",
+    "name": "姓名",
+    "sect": "宗门",
+    "alignment": "阵营",
+    "death_time": "陨落时间",
+    "death_reason": "死因",
+    "age_at_death": "享年",
+    "realm_at_death": "终焉境界",
+    "backstory": "生平",
+    "events": "相关事件",
+    "no_events": "暂无相关事件",
+    "back_to_list": "返回列表",
+    "death_year": "第{year}年{month}月",
+    "rogue": "散修"
   }
 }

--- a/web/src/locales/zh-TW/game.json
+++ b/web/src/locales/zh-TW/game.json
@@ -434,5 +434,23 @@
       "runtime_effect_meta": "來源：{source} - 剩餘：{months}個月",
       "runtime_effect_meta_permanent": "來源：{source} - 持續：長期"
     }
+  },
+  "deceased": {
+    "title_short": "已故",
+    "title": "已故角色",
+    "empty": "暫無已故角色",
+    "name": "姓名",
+    "sect": "宗門",
+    "alignment": "陣營",
+    "death_time": "隕落時間",
+    "death_reason": "死因",
+    "age_at_death": "享年",
+    "realm_at_death": "終焉境界",
+    "backstory": "生平",
+    "events": "相關事件",
+    "no_events": "暫無相關事件",
+    "back_to_list": "返回列表",
+    "death_year": "第{year}年{month}月",
+    "rogue": "散修"
   }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -453,6 +453,27 @@ export interface DynastyDetailResponseDTO {
   officials: DynastyOfficialDTO[];
 }
 
+// --- Deceased Characters ---
+
+export interface DeceasedRecordDTO {
+  id: string;
+  name: string;
+  gender: string;
+  age_at_death: number;
+  realm_at_death: string;
+  stage_at_death: string;
+  death_reason: string;
+  death_time: number;
+  sect_name_at_death: string;
+  alignment_at_death: string;
+  backstory: string | null;
+  custom_pic_id: number | null;
+}
+
+export interface DeceasedListResponseDTO {
+  deceased: DeceasedRecordDTO[];
+}
+
 export type ToastLevel = 'error' | 'warning' | 'success' | 'info' | string;
 export type AppLanguage = AppLocale | string;
 


### PR DESCRIPTION
## Summary

- 新增已故角色独立存档与管理功能，已故角色信息和事件不受 `cleanup_long_dead_avatars` 清理影响
- 在首页状态栏添加"已故"入口（StatusWidget + clock-3 icon），点击打开已故角色列表弹窗，支持查看角色详情及相关事件
- 轻量级实现：使用 `DeceasedRecord` 快照替代完整 `Avatar` 对象，仅保存 11 个关键展示字段

## Implementation

### Backend

- **`DeceasedRecord`**：轻量数据类，保存 `id/name/gender/age_at_death/realm_at_death/stage_at_death/death_reason/death_time/sect_name_at_death/alignment_at_death/backstory/custom_pic_id`，提供 `to_dict()`/`from_dict()` 序列化
- **`DeceasedManager`**：独立管理器，`record_death(avatar)` 幂等写入，`get_all_records()` 按死亡时间倒序返回
- **死亡流程集成**：`death.py` 中 `handle_death` 后自动调用 `world.deceased_manager.record_death(avatar)`
- **存档持久化**：`save_game.py` 写入 `deceased_records`，`load_game.py` 读恢复
- **API 端点**：`GET /api/v1/query/deceased`，遵循现有 query/command 分离模式

### Frontend

- **`DeceasedModal.vue`**：列表视图（`NTable`）+ 详情视图（角色信息 + 相关事件），`shallowRef` 优化大列表性能
- **`StatusBar.vue`**：已故入口使用 `clock-3` Lucide icon，颜色走 `STATUS_BAR_COLORS.neutral`（`#8c8c8c`），遵循模块基础色分层约定
- **Mapper 层**：`api/mappers/deceased.ts` 将 DTO 转为视图模型，派生 `deathYear`/`deathMonth`
- **i18n**：5 种语言（zh-CN / en-US / zh-TW / ja-JP / vi-VN）各新增 17 个翻译键

## Key Design Decisions

1. **独立管理器**：`DeceasedManager` 与 `AvatarManager` 解耦，已故档案不受 `cleanup_long_dead_avatars` 影响
2. **轻量快照**：`DeceasedRecord` 仅保存展示必要字段（~11 个），不持有完整 Avatar 引用，内存占用极小
3. **幂等写入**：`record_death()` 以 `avatar.id` 为 dict key，重复调用安全覆盖
4. **事件独立性**：事件系统基于 ID 关系存储（SQLite），角色清理后事件仍可通过 `/api/v1/query/events` 查询
5. **阵营翻译**：`alignment_at_death` 使用 `str(avatar.alignment)` 而非 `.value`，确保存储翻译后文本
6. **StatusBar 对齐**：颜色走 `STATUS_BAR_COLORS.neutral` 常量而非硬编码，遵循 AGENTS.md 第 16 条模块基础色与状态覆盖色分层约束

## Files Changed (24 files)

| Category | Files |
|---|---|
| New Backend | `src/classes/deceased_record.py`, `src/sim/managers/deceased_manager.py` |
| Backend Core | `src/classes/core/world.py`, `src/classes/death.py`, `src/sim/save/save_game.py`, `src/sim/load/load_game.py` |
| Backend API | `src/server/services/game_queries.py`, `src/server/public_query_builders.py`, `src/server/api/public_v1/query.py`, `src/server/host_app.py`, `src/server/main.py` |
| New Frontend | `web/src/api/mappers/deceased.ts`, `web/src/components/game/panels/DeceasedModal.vue` |
| Frontend | `web/src/types/api.ts`, `web/src/api/modules/world.ts`, `web/src/components/layout/StatusBar.vue` |
| i18n (5 locales) | `zh-CN/game.json`, `en-US/game.json`, `zh-TW/game.json`, `ja-JP/game.json`, `vi-VN/game.json` |
| Tests | `tests/test_deceased_manager.py` (7 tests), `tests/test_public_api_v1.py` (+2 tests), `web/src/__tests__/components/StatusBar.test.ts` (+1 test) |

## Test Plan

- [x] `tests/test_deceased_manager.py`：7 项测试覆盖 record_death 创建、幂等性、排序、序列化往返、cleanup 独立性、存档恢复、空管理器边界
- [x] `tests/test_public_api_v1.py`：deceased 端点 503/200 响应测试
- [x] `web/src/__tests__/components/StatusBar.test.ts`：已故 widget 渲染、颜色、索引断言
- [x] 后端 34 项测试全部通过
- [x] 前端 24 项测试全部通过
- [x] locale 对齐检查通过

🤖 Generated with [Qoder](https://qoder.com)