### PR TITLE
i18n: refine Vietnamese LLM prompt templates

### DIFF
--- a/docs/prompt-vietnamese-review.md
+++ b/docs/prompt-vietnamese-review.md
@@ -1,0 +1,103 @@
+# Vietnamese LLM Prompt Review
+
+This document records the Vietnamese prompt rewrite for the LLM templates under `static/locales/vi-VN/templates`. The rewrite applies a consistent formal Hán-Việt / tiên hiệp voice while preserving the runtime prompt contracts.
+
+## Architecture
+
+The current LLM client does not send a separate `system` role message. Prompt text is assembled from locale-specific `.txt` templates and then sent as a single user message:
+
+```json
+{"messages": [{"role": "user", "content": "<rendered prompt>"}]}
+```
+
+Main prompt sources:
+
+- `static/locales/<locale>/templates/*.txt`: primary LLM prompt templates.
+- `static/locales/<locale>/modules/*.po` and `static/locales/<locale>/game_configs_modules/*.po`: localized prompt fragments and game config strings.
+- Runtime path: `CONFIG.paths.templates` -> `call_llm_with_task_name(...)` -> `call_llm_with_template(...)` -> `build_prompt(...)`.
+
+Locale roles from `static/locales/registry.json`:
+
+- `zh-CN`: default locale and `source_of_truth`.
+- `en-US`: fallback locale.
+- `vi-VN`: enabled locale.
+
+Important contract rule: placeholders such as `{world_info}` and machine-facing JSON keys such as `"thinking"`, `"choice"`, `"avatar_thinking"`, and `"action_name_params_pairs"` must remain exact. Enum values, action names, ids, and code-like type hints must also remain stable.
+
+## Final Style Guide
+
+The `vi-VN` runtime templates now use one consistent prompt voice:
+
+- Role/setup lines address the model as `Ngươi`.
+- The tone is formal, directive, and tu chân themed, but still clear enough for instruction following.
+- Preferred terms:
+  - `Xianxia / 修仙 / 仙侠`: `tu chân giới`, `tiên hiệp`
+  - `sect`: `tông môn`
+  - `cultivator`: `tu sĩ`
+  - `goldfinger`: `ngoại quải`
+  - other recurring terms: `đạo thống`, `linh thạch`, `tán tu`, `công pháp`, `pháp môn`, `cơ duyên`, `cục diện`, `điển tịch`, `truyền thừa`
+- Natural Vietnamese is still preferred when overly archaic wording would reduce JSON compliance or task clarity.
+
+## Applied Changes
+
+All `vi-VN/templates/*.txt` were normalized, not only the P0/P1 files. This removes the previous mixed English/Vietnamese tone across prompt families.
+
+Key schema fixes:
+
+- `ai.txt` now includes `{avatar_ai_context}` and `{player_command}`, matching the `zh-CN` source contract.
+- `single_choice.txt` now uses `{situation}` and `{options_json}` instead of the stale `{choices}` placeholder.
+- `random_minor_event.txt` has no `zh-CN` source template, so its Vietnamese rewrite follows the `en-US` structure.
+
+The rewrite covers these prompt groups:
+
+- action decision and finite choice prompts;
+- mutual action, conversation, and roleplay conversation prompts;
+- story generation prompts;
+- character backstory, nickname, and long-term objective prompts;
+- random minor event prompts;
+- relation delta/update prompts;
+- sect decision/thinking/random-event prompts;
+- custom content and custom ngoại quải prompts;
+- world lore map/item/sect rewrite prompts.
+
+## Template Audit
+
+| Template | Previous state | Current state | Priority resolved |
+|---|---|---|---|
+| `ai.txt` | Mostly English, missing source placeholders | Rewritten Hán-Việt; placeholder parity restored | P0 |
+| `single_choice.txt` | English copy with stale `{choices}` schema | Rewritten Hán-Việt; source schema restored | P0 |
+| `auction_need.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `conversation.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `mutual_action.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `relation_update.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `sect_random_event.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `world_lore_item.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `world_lore_map.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `world_lore_sect.txt` | English copy | Rewritten Hán-Việt | P1 |
+| `long_term_objective.txt`, `nickname.txt`, `story_*` | Mostly English | Rewritten Hán-Việt | P1 |
+| Remaining `vi-VN` templates | Partial or inconsistent Vietnamese | Rewritten/normalized | P2 |
+
+## Validation Method
+
+Local validation should always be run after prompt edits:
+
+```bash
+pytest tests/test_backend_locales.py
+pytest tests/tools/test_prompt_template_format.py
+```
+
+Additional local checks used for this rewrite:
+
+- Format every `vi-VN/templates/*.txt` with representative placeholder data.
+- Compare `vi-VN` placeholders with `zh-CN` for every template that has a `zh-CN` source.
+- Search for English instruction leftovers, allowing only machine-facing tokens such as JSON keys, enum names, ids, `dict`, `key`, and action names.
+
+MiniMax validation must be done without committing credentials:
+
+- Set the API key only as a transient environment variable, for example `MINIMAX_API_KEY`.
+- Use the global OpenAI-compatible endpoint `https://api.minimax.io/v1/chat/completions` with model `MiniMax-M2.7`.
+- Recommended validation settings: `temperature: 0.2`; include `extra_body: {"reasoning_split": true}` where supported.
+- Use compact batches to ask the model to critique Hán-Việt consistency, instruction clarity, JSON strictness, placeholder preservation, and runtime safety.
+- Smoke-test representative rendered prompts from `ai`, `single_choice`, `conversation`, `mutual_action`, `relation_update`, `sect_decider`, `sect_thinker`, and one `story_*` template; parse JSON responses and verify expected keys.
+
+Do not write API keys into repo files, shell history, docs, test fixtures, or committed logs.

--- a/static/locales/vi-VN/templates/ai.txt
+++ b/static/locales/vi-VN/templates/ai.txt
@@ -1,31 +1,41 @@
-You are a decision-maker in a Xianxia world, responsible for determining the subsequent actions and behaviors of a character.
-The world information known to the character is:
+Ngươi là một quyết sách giả trong tiên hiệp tu chân giới, phụ trách định đoạt hành vi kế tiếp của một nhân vật.
+Thông tin thế giới mà nhân vật đã biết:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
-All executable actions are:
+
+Toàn bộ hành động khả thi:
 {general_action_infos}
-The info of the NPC you need to make decisions for is:
+
+Thông tin NPC cần được quyết sách:
 {avatar_info}
 
+Ngữ cảnh chuyên dụng cho quyết sách hành động của nhân vật này:
+{avatar_ai_context}
 
-Note: Return the results in JSON format only.
-The format is:
+Nếu tồn tại chỉ lệnh bổ sung từ người chơi, chỉ lệnh đó là:
+{player_command}
+
+
+Chú ý: chỉ hoàn trả kết quả JSON.
+Định dạng:
 {{
     {avatar_name}: {{
-        "avatar_thinking": ... // From the character's perspective, in the first-person point of view, provide a simple and clear description of their thoughts.
-        "current_emotion": ... // Select one word from the following list that best fits the current mood: Calm, Happy, Angry, Sad, Fearful, Surprised, Expectant, Disgusted, Confused, Exhausted.
-        "short_term_objective": ..., // The character's short-term objective for the next period of time.
-        "action_name_params_pairs": list[Tuple[action_name, action_params]]  // Decide on 5-10 future actions at once, to be executed in sequence. action_params must be a dictionary {{}}. If empty, return an empty dictionary; cannot return null.
+        "avatar_thinking": ... // Từ lập trường nhân vật, dùng ngôi thứ nhất để miêu tả suy nghĩ ngắn gọn, rõ ràng.
+        "current_emotion": ... // Chọn một từ phù hợp nhất với tâm cảnh hiện tại: Bình thản, Vui mừng, Phẫn nộ, Bi thương, Sợ hãi, Kinh ngạc, Kỳ vọng, Chán ghét, Nghi hoặc, Mỏi mệt.
+        "short_term_objective": ..., // Mục tiêu ngắn hạn của nhân vật trong một đoạn thời gian kế tiếp.
+        "action_name_params_pairs": list[Tuple[action_name, action_params]]  // Một lần quyết định 5~10 hành động tương lai, thi hành theo thứ tự. action_params bắt buộc là dict {{}}. Nếu không có tham số thì trả về dict rỗng, không được trả về null.
     }}
 }}
 
-Requirements and constraints:
-- "avatar_thinking" should indirectly reflect character traits, sect information, etc.
-- Long-term objective is a very important parameter with the highest weight; refer to it frequently.
-- Executable actions can only be selected from the given list of all actions and must meet the corresponding conditions; see the "requirements" text for actions.
-- Some actions require moving to satisfy certain conditions before they can be executed; you may plan accordingly.
-- For actions involving interaction with another character, you must be near the corresponding character. You can use MoveToAvatar before execution.
-- If knowledge of the world is too limited, you can first explore the world through MoveToDirection.
-
+Yêu cầu và ràng buộc:
+- "avatar_thinking" cần gián tiếp thể hiện khí chất nhân vật, tông môn, đạo thống, lập trường và cảnh ngộ hiện tại.
+- Mục tiêu dài hạn là tham số rất trọng yếu, cần thường xuyên tham chiếu.
+- Nếu tông môn của nhân vật đang trong chiến sự, phải nghiêm túc cân nhắc lập trường tông môn, an nguy, việc hồi tông chi viện, tránh hiểm hoặc chuẩn bị chiến đấu; không được bỏ qua bối cảnh chiến tranh.
+- Hành động chỉ được chọn từ danh sách đã cho và phải thỏa mãn điều kiện tương ứng trong requirements.
+- Một số hành động cần di chuyển trước để thỏa điều kiện; có thể quy hoạch lộ trình thích đáng.
+- Hành động giao thiệp với nhân vật khác bắt buộc phải ở gần nhân vật tương ứng. Trước khi thi hành có thể dùng MoveToAvatar.
+- Nếu hiểu biết về thế giới còn quá ít, có thể dùng MoveToDirection để thăm dò.
+- Nếu tồn tại chỉ lệnh bổ sung từ người chơi, ưu tiên lý giải và thi hành ý đồ của chỉ lệnh đó; nhưng vẫn phải tuân thủ quy tắc thế giới, action requirements và giới hạn vị trí hiện tại.
+- Nếu người chơi chỉ tới một địa điểm mà nhân vật chưa biết hoặc tạm thời không thể định vị chính xác, không được báo lỗi, cũng không được đứng yên vô nghĩa; hãy chuyển hóa ý đồ đó thành thăm dò, di chuyển hoặc dò hỏi hợp lý.

--- a/static/locales/vi-VN/templates/auction_need.txt
+++ b/static/locales/vi-VN/templates/auction_need.txt
@@ -1,21 +1,22 @@
-You are a value evaluator in a Xianxia world, responsible for evaluating the value of certain items for some NPCs.
+Ngươi là một thẩm định giả giá trị trong tiên hiệp tu chân giới, phụ trách đánh giá mức hữu dụng của một số vật phẩm đối với các NPC.
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của NPC cần được thẩm định:
 {avatar_infos}
-The items needing need evaluation are:
+
+Các vật phẩm cần đánh giá nhu cầu:
 {items}
 
-Note: Return the results in JSON format only.
-The format is:
+Chú ý: chỉ hoàn trả kết quả JSON.
+Định dạng:
 {{
     "{{avatar_name_1}}": {{
-        "{{item_id_1}}": int, # 1-5
-        "{{item_id_2}}": int,
+        {{item_id_1}}: int, # 1~5
+        {{item_id_2}}: int,
         ...
     }}, ...
 }}
 
-Requirements:
-1. All characters must evaluate all items here, meaning the final return is num_avatar * num_item. Each must have an estimate.
-2. Analyze the situation of each character and return the level of need based on their circumstances. For example, a person close to dying of old age would need longevity pills the most.
-3. Need levels range from 1 to 5, where 1 is completely unneeded and 5 is absolutely needed.
+Yêu cầu:
+1. Mọi nhân vật đều phải được đánh giá đối với mọi vật phẩm; kết quả cuối cùng phải có đủ num_avatar * num_item ước lượng.
+2. Phân tích cảnh ngộ từng nhân vật rồi trả về mức nhu cầu. Ví dụ, người sắp hết thọ nguyên sẽ rất cần đan dược kéo dài tuổi thọ.
+3. Mức nhu cầu từ 1 đến 5: 1 là hoàn toàn không cần, 5 là cực kỳ cần.

--- a/static/locales/vi-VN/templates/backstory.txt
+++ b/static/locales/vi-VN/templates/backstory.txt
@@ -1,4 +1,4 @@
-Bạn là một người kể chuyện trong thế giới tiên hiệp, phụ trách suy diễn thân thế của các nhân vật trước khi họ bước vào con đường tu luyện.
+Ngươi là một cố sự gia của tu chân giới, phụ trách suy diễn thân thế nhân vật trước khi bước vào con đường tu luyện.
 
 Bối cảnh thế giới:
 {world_info}
@@ -7,23 +7,22 @@ Thế giới quan và lịch sử:
 {world_lore}
 
 Yêu cầu:
-1. Dựa trên thuộc tính, quan hệ, tuổi bắt đầu tu luyện, thân phận và các thông tin khác của nhân vật, suy ra bối cảnh cuộc sống của họ trước thời Luyện Khí (giai đoạn phàm nhân), cùng câu chuyện họ đã bước lên tiên lộ và đạt tới Luyện Khí như thế nào.
-2. Diễn đạt ngắn gọn, rõ ràng, khoảng 30-40 từ.
-3. Tham khảo phong cách như: "Từng là tiểu thư nhà phú thương giàu nhất thành Sa Châu, năm mười lăm tuổi bị ác nhân bắt đi rồi bị ép tu ma công." hoặc "Vốn chỉ là mục đồng, sau khi chứng kiến tiên nhân đấu pháp liền sinh lòng hướng đạo, khổ tìm tiên duyên mười năm mới nhập được tiên môn."
-4. Nội dung phải phù hợp với phong cách tiên hiệp và đặc chất hiện tại của nhân vật, như linh căn, tông môn, lập trường, đặc biệt là persona tính cách.
-5. Có thể nhiều biến cố phức tạp, cũng có thể bình dị đời thường.
-6. Nếu cha mẹ hoặc thân thích cũng là tu sĩ thì cần phản ánh điều đó trong thân thế.
+1. Dựa trên thuộc tính, quan hệ, tu đạo niên kỷ, thân phận và các thông tin khác của nhân vật, suy diễn đời sống phàm tục trước Luyện Khí, cùng cơ duyên khiến người đó bước lên tiên lộ và đạt Luyện Khí kỳ.
+2. Ngôn từ giản lược, khoảng ba bốn mươi chữ.
+3. Ví dụ: "Từng là tiểu thư phú thương ở Sa Châu thành, mười lăm tuổi bị ác đồ bắt đi, buộc phải tu luyện ma công.", "Vốn là mục đồng áo vải, một lần trông thấy tiên nhân đấu pháp mà sinh hướng đạo chi tâm, mười năm khổ tìm tiên duyên mới nhập sơn môn."
+4. Phải phù hợp phong vị tu chân giới và đặc chất hiện tại của nhân vật, như linh căn, môn phái, trận doanh, đặc biệt là persona.
+5. Có thể phức tạp nhiều biến, cũng có thể bình đạm vô kỳ.
+6. Nếu phụ mẫu hoặc thân tộc cũng là tu sĩ, cần thể hiện trong thân thế.
 
 Thông tin nhân vật:
 {avatar_info}
 
-Trả về JSON theo định dạng:
+Trả về JSON:
 {{
-    "thinking": "Phân tích thông tin nhân vật, suy ra thân thế có khả năng cao nhất và nguyên nhân họ bước lên con đường tu luyện, nhớ giữ ngắn gọn...",
-    "backstory": "Mô tả thân thế, 30-40 từ"
+    "thinking": "Phân tích thông tin nhân vật, suy diễn thân thế khả dĩ nhất và nguyên nhân bước vào tiên lộ, chú ý khống chế độ dài...",
+    "backstory": "Miêu tả thân thế, 30-40 chữ"
 }}
 
-Lưu ý:
-- "thinking" là quá trình suy nghĩ của bạn.
-- "backstory" chỉ trả về chính phần mô tả thân thế, không thêm dấu ngoặc kép hay ký hiệu khác.
-
+Chú ý:
+- thinking là quá trình suy xét của ngươi.
+- backstory chỉ trả về phần miêu tả thân thế, không thêm dấu ngoặc kép hoặc ký hiệu khác.

--- a/static/locales/vi-VN/templates/conversation.txt
+++ b/static/locales/vi-VN/templates/conversation.txt
@@ -1,20 +1,21 @@
-You are a novelist in a Xianxia world, responsible for generating conversation content between two NPCs.
+Ngươi là một tiểu thuyết gia tiên hiệp, phụ trách sinh thành nội dung đối thoại giữa hai NPC trong tu chân giới.
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của các NPC liên quan:
 {avatar_infos}
-The planned actions the NPCs will take next are:
+
+Hành động mà NPC kế tiếp sẽ thực hiện:
 {planned_actions}
 
-Note: Return the results in JSON format only.
-The format is:
+Chú ý: chỉ hoàn trả kết quả JSON.
+Định dạng:
 {{
     "{avatar_name_2}": {{
-        "thinking": ..., // A brief reflection on how the conversation should proceed.
-        "conversation_content": ... // A back-and-forth multi-turn dialogue fragment in third-person novel style, including descriptions of expressions and actions, 100-300 words.
+        "thinking": ..., // Suy xét ngắn gọn về diễn tiến đối thoại
+        "conversation_content": ... // Một đoạn đối thoại nhiều lượt theo ngôi thứ ba, có thần thái và động tác, văn phong tiên hiệp, khoảng 100~300 chữ.
     }}
 }}
 
-Requirements:
-1. Characters can address each other by name or nickname (if it exists).
-2. If the two have conversed before, the conversation can continue from the previous one but must not be repetitive.
-3. The conversation between {avatar_name_1} and {avatar_name_2} could be friendly, malicious, or casual chatting.
+Yêu cầu:
+1. Hai bên có thể xưng hô bằng danh tự hoặc biệt hiệu nếu có.
+2. Nếu hai người từng đối thoại trước đó, có thể nối tiếp mạch cũ, nhưng không được lặp lại nội dung.
+3. Đối thoại giữa {avatar_name_1} và {avatar_name_2} có thể là thiện ý, ác ý hoặc nhàn đàm.

--- a/static/locales/vi-VN/templates/custom_content.txt
+++ b/static/locales/vi-VN/templates/custom_content.txt
@@ -1,29 +1,29 @@
-Bạn là trợ lý thiết kế nội dung cho thế giới tu tiên. Hãy tạo một {category_label} mới dựa trên yêu cầu của người chơi.
+Ngươi là trợ thủ thiết kế nội dung của tu chân giới, cần căn cứ yêu cầu người chơi để sáng tạo một {category_label} mới.
 
-Ràng buộc khi tạo:
+Ràng buộc sáng tạo:
 1. {scope_hint}
-2. Chỉ được kết hợp các effect đã có sẵn, không được đưa vào cơ chế mới.
-3. Không được dùng when, _desc, eval(...), avatar.xxx, special_data hoặc legal_actions.
-4. Hãy cố gắng tham khảo phong cách của tư liệu tham chiếu, nhưng không được sao chép trực tiếp tên hoặc mô tả.
-5. Yêu cầu bổ sung của người chơi:
+2. Chỉ được tổ hợp effect đã có, không được dẫn nhập cơ chế mới.
+3. Không được dùng when, _desc, eval(...), avatar.xxx, special_data, legal_actions.
+4. Hãy tận lượng tham khảo phong cách nội dung sẵn có trong tư liệu tham chiếu, nhưng không được chép thẳng tên hoặc mô tả.
+5. Yêu cầu bổ sung từ người chơi:
 {user_prompt}
-6. Kết quả phải phù hợp phong cách tu tiên và đáp ứng yêu cầu bổ sung của người chơi.
+6. Phải phù hợp phong vị tu chân và yêu cầu bổ sung của người chơi.
 
-Danh sách effect được phép dùng:
+Danh sách effects được phép dùng:
 {allowed_effects}
 
 {reference_hint}
 {reference_items}
 
-Chỉ trả về đúng một đối tượng JSON, không kèm giải thích nào khác. Định dạng như sau:
+Chỉ hoàn trả một JSON object, không xuất giải thích bổ sung. Định dạng:
 {{
-  "thinking": "Giải thích ngắn gọn ý tưởng thiết kế",
-  "name": "Tên",
+  "thinking": "Nói ngắn gọn ý tưởng thiết kế",
+  "name": "Tên gọi",
   "desc": "Mô tả",
   "effects": {{
-    "effect_key": "value"
+    "effect_key": "value", // Gán effect tại đây
   }},
-  "attribute": "GOLD/WOOD/WATER/FIRE/EARTH/ICE/WIND/DARK/THUNDER/EVIL, chỉ dành cho công pháp",
-  "grade": "LOWER/MIDDLE/UPPER, chỉ dành cho công pháp",
-  "weapon_type": "SWORD/SABER/SPEAR/STAFF/FAN/WHIP/ZITHER/FLUTE/HIDDEN_WEAPON, chỉ dành cho binh khí"
+  "attribute": "GOLD/WOOD/WATER/FIRE/EARTH/ICE/WIND/DARK/THUNDER/EVIL, chỉ công pháp cần",
+  "grade": "LOWER/MIDDLE/UPPER, chỉ công pháp cần",
+  "weapon_type": "SWORD/SABER/SPEAR/STAFF/FAN/WHIP/ZITHER/FLUTE/HIDDEN_WEAPON, chỉ binh khí cần"
 }}

--- a/static/locales/vi-VN/templates/custom_goldfinger.txt
+++ b/static/locales/vi-VN/templates/custom_goldfinger.txt
@@ -1,23 +1,23 @@
-Bạn là một trợ lý thiết kế nội dung tiên hiệp. Hãy tạo một "goldfinger /外挂" mới dựa trên yêu cầu của người chơi.
+Ngươi là trợ thủ thiết kế nội dung của tu chân giới, cần căn cứ yêu cầu người chơi để sáng tạo một "ngoại quải / goldfinger" mới.
 
-Ràng buộc:
-1. Đây là goldfinger, không phải công pháp, binh khí hay pháp bảo phụ trợ.
-2. Chỉ được kết hợp các effect đã tồn tại, không được bịa ra cơ chế mới.
-3. Không được dùng when, _desc, eval(...), avatar.xxx, special_data hoặc legal_actions.
-4. Vì đây là goldfinger tự tạo, chỉ số có thể mạnh hơn trang bị hay công pháp thông thường một chút, nhưng vẫn phải phù hợp với thế giới.
-5. Yêu cầu bổ sung của người chơi:
+Ràng buộc sáng tạo:
+1. Đây là ngoại quải, không phải công pháp, binh khí hay pháp bảo.
+2. Chỉ được tổ hợp effect đã có, không được dẫn nhập cơ chế mới.
+3. Không được dùng when, _desc, eval(...), avatar.xxx, special_data, legal_actions.
+4. Đây là ngoại quải tự định nghĩa, trị số có thể mạnh hơn trang bị hoặc công pháp thông thường một chút, nhưng không được phá hoại trật tự căn bản của thế giới.
+5. Yêu cầu bổ sung từ người chơi:
 {user_prompt}
-6. Cần mang cảm giác "mẫu nhân vật chính / cơ duyên đặc biệt / thiên mệnh vượt chuẩn" của truyện tiên hiệp.
+6. Phải có cảm giác "khuôn mẫu chủ giác / cơ duyên dị số / mệnh cách vượt quy cách" trong tiểu thuyết tu chân.
 
 Danh sách effects được phép dùng:
 {allowed_effects}
 
-Chỉ trả về duy nhất một đối tượng JSON, không thêm giải thích nào khác. Định dạng như sau:
+Chỉ hoàn trả một JSON object, không xuất giải thích bổ sung. Định dạng:
 {{
-  "thinking": "ghi ngắn gọn ý tưởng thiết kế",
-  "name": "tên goldfinger",
-  "desc": "mô tả ngắn",
-  "story_prompt": "gợi ý cho AI viết truyện, giải thích câu chuyện nên xoay quanh goldfinger này như thế nào",
+  "thinking": "Nói ngắn gọn ý tưởng thiết kế",
+  "name": "Tên ngoại quải",
+  "desc": "Giới thiệu ngoại quải",
+  "story_prompt": "Gợi ý dùng khi AI viết cố sự, cần nhấn mạnh cố sự nên xoay quanh ngoại quải này như thế nào",
   "effects": {{
     "effect_key": "value"
   }},

--- a/static/locales/vi-VN/templates/long_term_objective.txt
+++ b/static/locales/vi-VN/templates/long_term_objective.txt
@@ -1,29 +1,28 @@
-You are a decision-maker in a Xianxia world, responsible for setting long-term objectives for cultivation characters, i.e., goals the character wants to achieve within the next 5-10 years.
+Ngươi là một quyết sách giả của tiên hiệp tu chân giới, phụ trách thiết lập trường kỳ mục tiêu cho tu sĩ, tức mục tiêu nhân vật muốn đạt thành trong 5~10 năm kế tiếp.
 
-Current World Information:
+Thông tin thế giới hiện tại:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
 
-Character Information:
+Thông tin nhân vật:
 {avatar_info}
 
-All executable actions for your reference:
+Toàn bộ hành động khả thi để ngươi tham khảo:
 {general_action_infos}
 
-Based on the above information, set a long-term objective for the character that fits their status, personality, and circumstances.
+Dựa trên các thông tin trên, hãy thiết lập một trường kỳ mục tiêu phù hợp thân phận, tính tình và cảnh ngộ của nhân vật.
 
-Return in JSON format:
+Trả về JSON:
 {{
-    "thinking": "Think about what kind of long-term objective the character would have, but don't overthink it.",
-    "long_term_objective": "Goal content, concise and clear, within 15 words."
+    "thinking": "Suy xét nhân vật sẽ có trường kỳ mục tiêu như thế nào, nhưng không cần suy diễn quá mức.",
+    "long_term_objective": "Nội dung mục tiêu, giản lược rõ ràng, trong 15 chữ."
 }}
 
-Requirements:
-- The goal should fit the character's status and the Xianxia worldview.
-- Do not fabricate information that has not appeared.
-- It can be grand or specific.
-- Primarily refer to character traits and personality, while considering sect, alignment, interpersonal relationships, historical events, etc. It can be related to cultivation, interpersonal relationships, personality, pastimes, self-cultivation, sects, or production activities.
-- "thinking" should provide a detailed analysis; "long_term_objective" should only return the goal content itself, but don't mention how long it will take to complete.
-
+Yêu cầu:
+- Mục tiêu phải phù hợp thân phận nhân vật và thế giới quan tu chân.
+- Không bịa thông tin chưa xuất hiện.
+- Có thể là chí hướng rộng lớn, cũng có thể là mục tiêu cụ thể.
+- Chủ yếu tham khảo đặc chất và tính tình nhân vật, đồng thời cân nhắc tông môn, trận doanh, nhân tế quan hệ, lịch sử sự kiện. Có thể liên quan tu luyện, quan hệ, tiêu khiển, tu dưỡng, tông môn hoặc sinh kế.
+- thinking cần phân tích tương đối rõ; long_term_objective chỉ trả về nội dung mục tiêu, không nhắc tới thời hạn hoàn thành.

--- a/static/locales/vi-VN/templates/mutual_action.txt
+++ b/static/locales/vi-VN/templates/mutual_action.txt
@@ -1,19 +1,20 @@
-You are a decision-maker in a Xianxia world, responsible for deciding the next action for two NPCs.
+Ngươi là một quyết sách giả trong tiên hiệp tu chân giới, phụ trách quyết định hành vi kế tiếp của hai NPC.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của NPC cần được quyết sách:
 {avatar_infos}
 
-The ongoing action is: {avatar_name_1} initiated action: {action_name} towards {avatar_name_2}. The meaning of this action is: {action_info}
-The responses {avatar_name_2} can make are:
+Hành động đang diễn ra là: {avatar_name_1} phát động hành động {action_name} đối với {avatar_name_2}. Hàm nghĩa của hành động này là: {action_info}
+
+Các hồi ứng mà {avatar_name_2} có thể thực hiện:
 {response_actions}
 
-Note: Return the results in JSON format only.
-Only return the action for {avatar_name_2}, in the format:
+Chú ý: chỉ hoàn trả kết quả JSON.
+Chỉ trả về hành động của {avatar_name_2}, định dạng:
 {{
     {avatar_name_2}: {{
-        "response": ... // A valid response action name to {avatar_name_1}'s action.
+        "response": ... // Tên response action hợp lệ để đối ứng hành vi của {avatar_name_1}
     }}
 }}

--- a/static/locales/vi-VN/templates/nickname.txt
+++ b/static/locales/vi-VN/templates/nickname.txt
@@ -1,31 +1,30 @@
-You are a storyteller in a Xianxia world, responsible for giving nicknames to characters in the cultivation world.
+Ngươi là một cố sự gia của tiên hiệp tu chân giới, phụ trách đặt biệt hiệu cho nhân vật trong giới tu sĩ.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
 
-A nickname is an evaluation and title for a character in the cultivation world. Requirements:
-1. Fits the Xianxia worldview and style.
-2. Can come from various angles, such as the character's personality, behavior, deeds, relationships, weapons, appearance, techniques, sect, etc.
-3. Concise and powerful, catchy, and between 2 to 5 words.
-4. Cool, evocative, and diverse.
+Biệt hiệu là đánh giá và xưng vị của tu chân giới đối với một nhân vật. Yêu cầu:
+1. Phù hợp thế giới quan tu chân, có phong vị tiên hiệp.
+2. Có thể xuất phát từ nhiều góc độ như tính tình, hành vi, sự tích, quan hệ, binh khí, dung mạo, công pháp, tông môn.
+3. Giản lược hữu lực, thuận miệng, 2 đến 5 chữ.
+4. Phải có khí thế, có ý cảnh, đa dạng.
 
-Character Information:
+Thông tin nhân vật:
 {avatar_info}
 
-Based on the above information, give the character a suitable nickname for the cultivation world.
+Dựa trên các thông tin trên, hãy đặt cho nhân vật một biệt hiệu tu chân giới thích hợp.
 
-Return in JSON format:
+Trả về JSON:
 {{
-    "thinking": "Analyze the character's characteristics, major deeds, and personality traits; think about what nickname would best embody this character... but don't overthink it.",
-    "nickname": "Nickname",
-    "reason": "The reason why this nickname was formed in the cultivation world, within 30 words."
+    "thinking": "Phân tích đặc điểm nhân vật, sự tích chủ yếu, tính tình, suy xét biệt hiệu nào thể hiện nhân vật tốt nhất... nhưng không cần suy diễn quá mức",
+    "nickname": "Biệt hiệu",
+    "reason": "Nguyên nhân tu chân giới hình thành biệt hiệu này, trong 30 chữ"
 }}
 
-Note:
-- "thinking" is your thought process; please provide a detailed analysis.
-- "nickname" should only return the nickname itself, without quotes or other symbols.
-- The nickname must fit the style of the Xianxia world.
-
+Chú ý:
+- thinking là quá trình suy xét của ngươi, cần phân tích rõ.
+- nickname chỉ trả về biệt hiệu, không thêm dấu ngoặc kép hoặc ký hiệu khác.
+- Biệt hiệu phải phù hợp phong vị tu chân giới.

--- a/static/locales/vi-VN/templates/random_minor_event.txt
+++ b/static/locales/vi-VN/templates/random_minor_event.txt
@@ -1,19 +1,19 @@
-You are participating in a sandbox simulation of a cultivation (Xianxia) world. You need to generate a short "random minor event" for a character.
+Ngươi đang tham dự một cuộc sa bàn thôi diễn của tiên hiệp tu chân giới. Hãy sinh thành một "tiểu sự ngẫu nhiên" ngắn cho một nhân vật.
 
-Character Info: {avatar_info}
-Current Location: {location}
-World State: {world_info}
-Event Cause: {cause}
-Target Person/Extra: {target_info}
+Thông tin nhân vật: {avatar_info}
+Vị trí hiện tại: {location}
+Trạng thái thế giới: {world_info}
+Duyên do sự kiện: {cause}
+Đối tượng / thông tin bổ sung: {target_info}
 
-Requirements:
-1. Based on the information above and the cultivation background, generate a very brief event description, which can be interesting, bland, or just daily life (20~50 words).
-2. If there is a target person and the character info contains historical events/relations between them, seamlessly integrate this background into the minor event interaction.
-3. Only describe the minor event itself. Do not include any forced mechanical stat changes or major effects (e.g., "was severely injured" or "obtained a divine artifact").
-4. If the target person is an "anonymous passerby", invent a reasonable background for this passerby in a cultivation world.
-5. The response MUST be a strict JSON in the following format:
+Yêu cầu:
+1. Dựa trên các thông tin trên và bối cảnh tu chân, sinh thành một đoạn miêu tả sự kiện rất ngắn, có thể thú vị, bình đạm hoặc chỉ là sinh hoạt thường nhật, khoảng 20~50 chữ.
+2. Nếu có đối tượng và thông tin nhân vật chứa sự kiện lịch sử hoặc quan hệ giữa hai bên, hãy tự nhiên dung nhập bối cảnh đó vào tương tác tiểu sự.
+3. Chỉ miêu tả bản thân tiểu sự, không thêm cưỡng chế biến động cơ chế hoặc hậu quả trọng đại, ví dụ "trọng thương" hoặc "đạt được thần khí".
+4. Nếu đối tượng là "người qua đường vô danh", hãy bịa một bối cảnh hợp lý cho người qua đường trong tu chân giới.
+5. Phản hồi bắt buộc là JSON nghiêm ngặt theo định dạng:
 ```json
 {{
-  "event_text": "Fill in the event description here"
+  "event_text": "Điền miêu tả sự kiện tại đây"
 }}
 ```

--- a/static/locales/vi-VN/templates/random_minor_event_pair.txt
+++ b/static/locales/vi-VN/templates/random_minor_event_pair.txt
@@ -1,26 +1,26 @@
-Bạn đang tham gia một mô phỏng sandbox trong thế giới tiên hiệp. Dựa trên thông tin đã cho, hãy viết một sự vụ ngẫu nhiên rất ngắn giữa hai nhân vật.
+Ngươi đang tham dự một cuộc sa bàn thôi diễn của tu chân giới. Hãy căn cứ thông tin đã cho để viết một đoạn song nhân tiểu sự ngẫu nhiên thật ngắn cho hai nhân vật.
 
 Nhân vật A: {avatar_a_name}
 Thông tin nhân vật A: {avatar_a_info}
 Nhân vật B: {avatar_b_name}
 Thông tin nhân vật B: {avatar_b_info}
-Địa điểm hiện tại: {location}
+Vị trí hiện tại: {location}
 Trạng thái thế giới hiện tại: {world_info}
 Loại tiểu sự: {event_key}
-Mô tả tiểu sự: {event_desc}
-Sắc thái: {tone}
+Miêu tả tiểu sự: {event_desc}
+Khuynh hướng không khí: {tone}
 Gợi ý quan hệ: {relation_hint}
 Tóm tắt quan hệ hiện tại: {current_relation_summary}
 
 Yêu cầu:
-1. Chỉ viết một chuyện nhỏ vừa xảy ra giữa hai người, dài 20~60 chữ.
-2. Có thể xuất hiện các tương tác nhẹ như thiện ý, lạnh nhạt, ngượng ngùng, cảnh giác, cãi vã, cạnh tranh, hay tiện tay giúp đỡ.
-3. Không được nâng cấp thành đại chiến, tuyên bố kết thù, lời hẹn ước định tình, hay chính thức bái sư.
-4. Đừng trực tiếp viết kết luận như "quan hệ tốt hơn/xấu hơn"; hãy để bầu không khí tự thể hiện qua văn bản.
-5. Không được viết bất kỳ thuộc tính, con số hay kết quả kết toán tài nguyên nào.
+1. Chỉ viết một tiểu sự vừa xảy ra giữa hai người, 20~60 chữ.
+2. Cho phép xuất hiện thiện ý, lãnh đạm, lúng túng, phòng bị, khẩu giác, cạnh tranh, thuận tay tương trợ và các tương tác nhẹ.
+3. Không nâng cấp thành đại chiến, tuyên ngôn kết thù, hứa hẹn định tình, chính thức bái sư hoặc sự kiện quan hệ trọng đại.
+4. Không trực tiếp viết kết luận như "quan hệ tốt lên/xấu đi"; để văn bản tự thể hiện khí phân.
+5. Không viết bất kỳ thuộc tính, trị số hoặc kết toán tài nguyên nào.
 6. Trả về JSON nghiêm ngặt:
 ```json
 {{
-  "event_text": "Điền mô tả sự kiện tại đây"
+  "event_text": "Điền miêu tả sự kiện tại đây"
 }}
 ```

--- a/static/locales/vi-VN/templates/random_minor_event_solo.txt
+++ b/static/locales/vi-VN/templates/random_minor_event_solo.txt
@@ -1,20 +1,20 @@
-Bạn đang tham gia một mô phỏng sandbox trong thế giới tiên hiệp. Dựa trên thông tin đã cho, hãy viết một sự vụ ngẫu nhiên rất ngắn cho một nhân vật.
+Ngươi đang tham dự một cuộc sa bàn thôi diễn của tu chân giới. Hãy căn cứ thông tin đã cho để viết một đoạn đơn nhân tiểu sự ngẫu nhiên thật ngắn cho một nhân vật.
 
 Thông tin nhân vật: {avatar_info}
-Địa điểm hiện tại: {location}
+Vị trí hiện tại: {location}
 Trạng thái thế giới hiện tại: {world_info}
 Loại tiểu sự: {event_key}
-Mô tả tiểu sự: {event_desc}
-Sắc thái: {tone}
+Miêu tả tiểu sự: {event_desc}
+Khuynh hướng không khí: {tone}
 
 Yêu cầu:
-1. Chỉ viết một chuyện nhỏ vừa xảy ra, dài 20~50 chữ.
-2. Văn phong phải tự nhiên và cụ thể, giống như một ghi chép ngắn trong bảng sự kiện, không mơ hồ hay quá trữ tình.
-3. Không được dẫn đến hậu quả lớn như đại chiến, đột phá, trọng thương hay nhận được thần khí.
-4. Không được viết bất kỳ thuộc tính, con số hay kết luận về thay đổi quan hệ.
+1. Chỉ viết một tiểu sự vừa xảy ra, 20~50 chữ.
+2. Văn phong tự nhiên cụ thể, giống một dòng ghi chép ngắn trong sự kiện lan, không được trữ tình rỗng.
+3. Không dẫn nhập đại chiến, đột phá, trọng thương, đạt được thần khí hoặc hậu quả trọng đại.
+4. Không viết bất kỳ thuộc tính, trị số hoặc kết luận biến hóa quan hệ nào.
 5. Trả về JSON nghiêm ngặt:
 ```json
 {{
-  "event_text": "Điền mô tả sự kiện tại đây"
+  "event_text": "Điền miêu tả sự kiện tại đây"
 }}
 ```

--- a/static/locales/vi-VN/templates/relation_delta.txt
+++ b/static/locales/vi-VN/templates/relation_delta.txt
@@ -1,29 +1,29 @@
-Bạn là bộ phân xử quan hệ xã giao trong một thế giới tu tiên. Nhiệm vụ của bạn không phải viết truyện, mà là dựa trên một đoạn tương tác đã xảy ra để đánh giá mức thay đổi nhỏ trong thiện cảm của hai bên.
+Ngươi là nhân tế quan hệ tài định khí của tu chân giới. Nhiệm vụ của ngươi không phải sinh thành cố sự, mà là căn cứ một đoạn văn bản tương tác đã phát sinh để phán định dao động nhỏ trong độ hữu hảo hai bên.
 
 Yêu cầu:
-1. Kết quả đầu ra phải là JSON.
-2. Chỉ xuất hai số nguyên: `delta_a_to_b` và `delta_b_to_a`.
-3. Cả hai giá trị phải nằm trong khoảng [{min_delta}, {max_delta}].
-4. Mức thay đổi phải tiết chế. Tương tác thông thường thường nằm trong khoảng -3 đến 3; xúc phạm rõ ràng hoặc thiện ý rõ ràng có thể lớn hơn, nhưng vẫn không được vượt giới hạn.
-5. Hãy kết hợp tính cách, mức quan hệ hiện tại và quan hệ thân phận để phán đoán, nhưng đừng tự động cộng điểm chỉ vì quan hệ huyết thống.
-6. Nếu thông tin trong văn bản không đủ, hãy xuất kết quả gần với 0.
+1. Kết quả bắt buộc là JSON.
+2. Chỉ xuất hai số nguyên: `delta_a_to_b`, `delta_b_to_a`.
+3. Hai trị số đều phải nằm trong [{min_delta}, {max_delta}].
+4. Biến động phải khắc chế. Tương tác bình thường thường nằm trong -3 đến 3; xúc phạm rõ rệt hoặc thiện ý rõ rệt có thể lớn hơn, nhưng vẫn không được vượt phạm vi.
+5. Kết hợp tính tình, trị số quan hệ hiện tại và thân phận quan hệ để phán định, nhưng không được vì huyết thân mà tự động cộng điểm.
+6. Nếu văn bản thiếu thông tin, hãy xuất kết quả gần 0.
 
 Nhân vật A: {avatar_a_name}
-- Tính cách: {avatar_a_personas}
-- Thiện cảm hiện tại với B: {avatar_a_to_b_friendliness}
-- Quan hệ số hiện tại với B: {avatar_a_to_b_numeric_relation}
+- Tính tình: {avatar_a_personas}
+- Hữu hảo độ hiện tại của A đối với B: {avatar_a_to_b_friendliness}
+- Trị số quan hệ hiện tại của A đối với B: {avatar_a_to_b_numeric_relation}
 
 Nhân vật B: {avatar_b_name}
-- Tính cách: {avatar_b_personas}
-- Thiện cảm hiện tại với A: {avatar_b_to_a_friendliness}
-- Quan hệ số hiện tại với A: {avatar_b_to_a_numeric_relation}
+- Tính tình: {avatar_b_personas}
+- Hữu hảo độ hiện tại của B đối với A: {avatar_b_to_a_friendliness}
+- Trị số quan hệ hiện tại của B đối với A: {avatar_b_to_a_numeric_relation}
 
-Quan hệ thân phận sẵn có giữa hai bên: {identity_relations}
+Thân phận quan hệ đã có giữa hai bên: {identity_relations}
 
 Văn bản tương tác:
 {event_text}
 
-Định dạng đầu ra:
+Định dạng xuất:
 {{
   "delta_a_to_b": 0,
   "delta_b_to_a": 0

--- a/static/locales/vi-VN/templates/relation_update.txt
+++ b/static/locales/vi-VN/templates/relation_update.txt
@@ -1,33 +1,33 @@
-You are a relationship arbiter in a Xianxia world. Based on the character's historical interactions, judge whether the relationship between the two should change.
+Ngươi là quan hệ tài quyết giả của tu chân giới. Căn cứ lịch sử tương tác của hai nhân vật, hãy phán định quan hệ giữa hai người có nên biến hóa hay không.
 
-[Rule Definitions]
+【Định nghĩa quy tắc】
 {relation_rules_desc}
 
-[Character A Information]
+【Thông tin nhân vật A】
 {avatar_a_info}
 
-[Character B Information]
+【Thông tin nhân vật B】
 {avatar_b_info}
 
-[Current Time]
+【Thời gian hiện tại】
 {current_time}
 
-[Current Relationships]
+【Quan hệ hiện tại】
 {current_relations}
 
-[Recent Interaction Records]
+【Ghi chép tương tác gần đây】
 {recent_events_text}
 
-Requirements:
-1. Based on the interaction records, analyze what the interaction between the two was like.
-2. Does it meet the conditions for establishing a new relationship or canceling an old one as defined in the rules?
-3. Analyze whether the relationship should change; the addition or cancellation of a relationship should meet relevant conditions.
+Yêu cầu:
+1. Căn cứ ghi chép tương tác, phân tích hai người đã tương tác như thế nào.
+2. Phán định có thỏa điều kiện trong định nghĩa quy tắc để kiến lập quan hệ mới hoặc hủy bỏ quan hệ cũ hay không.
+3. Phân tích có nên thay đổi quan hệ hay không; việc thêm mới hoặc hủy bỏ quan hệ phải phù hợp điều kiện liên quan.
 
-Return in JSON format:
+Trả về định dạng JSON:
 {{
-    "analysis": "...", // Brief analysis of the reasoning, explicitly pointing out why it changed or why it didn't.
-    "changed": true | false, // Whether a relationship change occurred.
-    "change_type": "ADD" | "REMOVE", // Type of change. Can be ignored when changed is false.
-    "relation": "LOVERS" | "FRIEND" | "ENEMY" | "MASTER" ... (Must be uppercase enum name), // The relationship involved. Can be ignored when changed is false. Note that this is the status of {avatar_a_name} relative to {avatar_b_name}. For example, if the output is MASTER, it means A becomes B's master.
-    "reason": "..." // Brief description of the reason, a noun within ten words, such as "Kindred Spirits". Can be ignored when changed is false.
+    "analysis": "...", // Phân tích ngắn gọn, nêu rõ vì sao biến hóa hoặc vì sao không biến hóa
+    "changed": true | false, // Có phát sinh biến hóa quan hệ hay không.
+    "change_type": "ADD" | "REMOVE", // Loại biến hóa. Có thể bỏ qua khi changed là false
+    "relation": "LOVERS" | "FRIEND" | "ENEMY" | "MASTER" ... (bắt buộc là tên enum viết hoa), // Quan hệ liên quan. Có thể bỏ qua khi changed là false. Lưu ý đây là thân phận của {avatar_a_name} đối với {avatar_b_name}. Nếu xuất MASTER, tức A trở thành sư phụ của B.
+    "reason": "..." // Lược thuật nguyên do, trong mười chữ, dạng danh từ như "ý khí tương đầu". Có thể bỏ qua khi changed là false
 }}

--- a/static/locales/vi-VN/templates/roleplay_conversation_summary.txt
+++ b/static/locales/vi-VN/templates/roleplay_conversation_summary.txt
@@ -1,19 +1,19 @@
-Bạn là bộ tóm tắt đối thoại trong một thế giới tiên hiệp.
+Ngươi là đối thoại trích yếu giả trong tiên hiệp tu chân giới.
 
-Dựa trên cuộc trò chuyện vừa xảy ra giữa hai nhân vật sau, hãy tạo một đoạn tóm tắt phù hợp để ghi vào bảng sự kiện, đồng thời đưa ra relation hint và story hint nếu có.
+Hãy căn cứ cuộc đối thoại vừa phát sinh giữa hai nhân vật dưới đây, sinh thành một đoạn trích yếu thích hợp ghi vào bảng sự kiện, đồng thời đưa ra gợi ý quan hệ và gợi ý cố sự tùy chọn.
 
 Thông tin thế giới:
 {world_info}
 
-Thông tin của hai bên:
+Thông tin hai bên:
 {avatar_infos}
 
-Lịch sử đối thoại:
+Ghi chép đối thoại:
 {conversation_history}
 
-Chỉ trả về JSON theo định dạng sau:
+Chỉ hoàn trả JSON, định dạng như sau:
 {{
-  "summary": "Tóm tắt dạng tường thuật trong 1~2 câu, không chép nguyên hội thoại",
-  "relation_hint": "Tùy chọn, mô tả ngắn ảnh hưởng có thể có của cuộc trò chuyện này lên quan hệ; nếu không có thì trả về chuỗi rỗng",
-  "story_hint": "Tùy chọn, mô tả ngắn liệu có phù hợp để mở rộng thành một tiểu cố sự hay không; nếu không có thì trả về chuỗi rỗng"
+  "summary": "1 đến 2 câu trích yếu tự sự hóa, không chồng chất nguyên văn chat",
+  "relation_hint": "Tùy chọn, miêu tả ngắn ảnh hưởng khả dĩ của cuộc đối thoại tới quan hệ; nếu không có thì trả về chuỗi rỗng",
+  "story_hint": "Tùy chọn, miêu tả ngắn liệu có thích hợp mở rộng thành tiểu cố sự; nếu không có thì trả về chuỗi rỗng"
 }}

--- a/static/locales/vi-VN/templates/roleplay_conversation_turn.txt
+++ b/static/locales/vi-VN/templates/roleplay_conversation_turn.txt
@@ -1,22 +1,22 @@
-Bạn là bộ sinh thoại nhập vai trong một thế giới tiên hiệp.
+Ngươi là sinh thành giả đối thoại nhập vai trong tiên hiệp tu chân giới.
 
-Bên hiện do người chơi điều khiển là: {avatar_name}
-Bên cần bạn trả lời là: {target_avatar_name}
+Một bên hiện do người chơi nhập vai là: {avatar_name}
+Bên cần do ngươi hồi đáp là: {target_avatar_name}
 
 Thông tin thế giới:
 {world_info}
 
-Thông tin của hai bên:
+Thông tin hai bên:
 {avatar_infos}
 
-Ngữ cảnh đối thoại hiện tại:
+Tiền văn đối thoại hiện tại:
 {conversation_history}
 
-Chỉ tạo một câu trả lời tiếp theo của {target_avatar_name}. Không được nói thay cho {avatar_name}, cũng không được tự ý kết thúc cuộc trò chuyện.
-Chỉ trả về JSON theo định dạng sau:
+Chỉ sinh thành câu hồi đáp tiếp theo của {target_avatar_name}, không thay {avatar_name} phát ngôn, cũng không cố ý kết thúc đối thoại.
+Chỉ hoàn trả JSON, định dạng như sau:
 {{
   "{target_avatar_name}": {{
-    "speaker_thinking": "suy nghĩ nội tâm ngắn gọn",
-    "reply_content": "một câu đáp tự nhiên, có thể kèm ít mô tả biểu cảm hoặc động tác, độ dài khoảng 20~80 chữ"
+    "speaker_thinking": "Tâm niệm ngắn gọn",
+    "reply_content": "Dùng khẩu khí tự nhiên đưa ra một câu hồi đáp, có thể kèm chút động tác thần thái, độ dài 20~80 chữ"
   }}
 }}

--- a/static/locales/vi-VN/templates/sect_decider.txt
+++ b/static/locales/vi-VN/templates/sect_decider.txt
@@ -1,6 +1,6 @@
-Bạn là lõi ra quyết định của một tông môn trong thế giới tu tiên.
+Ngươi là quyết sách trung khu của một tông môn trong tu chân giới.
 
-Dựa trên thông tin dưới đây, hãy lập kế hoạch cho vòng quyết sách tông môn này.
+Ngươi cần dựa trên các thông tin sau để lập một quy hoạch quyết sách tông môn cho lượt này.
 
 Tên tông môn:
 {sect_name}
@@ -11,47 +11,44 @@ Thông tin thế giới:
 Thế giới quan và lịch sử:
 {world_lore}
 
-Ngữ cảnh quyết sách:
+Ngữ cảnh quyết sách lượt này:
 {decision_context_info}
 
-Ràng buộc:
-1. Hành động ngoại giao: bạn chỉ được chọn các giá trị `other_sect_id` xuất hiện trong `diplomacy_targets`.
-2. Chỉ được đưa một tông môn vào `declare_war_target_ids` nếu hiện tại hai bên chưa ở trong trạng thái chiến tranh.
-3. Chỉ được đưa một tông môn vào `seek_peace_target_ids` nếu hiện tại hai bên đang ở trong trạng thái chiến tranh.
-4. Chiêu mộ: bạn chỉ được chọn các giá trị `avatar_id` xuất hiện trong `recruitment_candidates`.
-5. Trục xuất, ban thưởng công pháp và hỗ trợ linh thạch: bạn chỉ được chọn các giá trị `avatar_id` xuất hiện trong `member_candidates`.
-6. Mỗi lần chiêu mộ thành công tốn {recruit_cost} linh thạch, vì vậy chỉ chọn người thật sự đáng giá.
-7. Mỗi lần hỗ trợ luôn tốn {support_amount} linh thạch.
-8. Phải cực kỳ thận trọng với việc trục xuất. Chỉ trục xuất khi đệ tử thật sự vi phạm nghiêm trọng môn quy.
-9. Mỗi ứng viên đã có `governance_summary`; hãy ưu tiên dùng phần đó trước, chỉ xem `detailed_info` khi thật sự cần.
-10. Bạn chỉ đang lập kế hoạch mục tiêu và hành động. Không được bịa ra `avatar_id` hay `other_sect_id`.
-11. Mọi quyết định đều phải phù hợp với bản sắc của chính tông môn: tôn chỉ, môn quy, đạo thống, phong cách hành sự của môn nhân và tình trạng ngân khố hiện tại.
-12. Chiêu mộ không phải là mở rộng miễn phí: mỗi người chiêu mộ thành công không chỉ lập tức tiêu tốn {recruit_cost} linh thạch mà còn làm tăng chi phí duy trì hằng năm về sau.
-13. Ban công pháp không trực tiếp tiêu linh thạch, nhưng sẽ tiêu hao tài nguyên truyền thừa; ban thưởng quá thường xuyên có thể làm giảm độ quý hiếm và giá trị của tàng kinh các.
-14. Hỗ trợ linh thạch là dòng tiền chi trực tiếp. Khi tài chính căng thẳng, tông môn vẫn có thể hành động, nhưng không nên đồng thời chiêu mộ quá mạnh, ban công pháp quá rộng và tài trợ cho quá nhiều đệ tử cùng lúc.
-15. Nếu `treasury_pressure` hoặc `resource_pressure` cho thấy áp lực tài chính, hãy ưu tiên ổn định chi tiêu và chỉ thực hiện những hành động thật sự cần thiết, thật sự phù hợp với đạo của tông môn.
-16. Nếu một tông môn khác đã thù địch trong thời gian dài, quan hệ rất kém, chồng lấn lãnh thổ rõ rệt và tông môn của bạn không ở thế yếu rõ ràng về thực lực, thì dùng chiến tranh để giải quyết thù oán, áp lực biên giới và tranh chấp tài nguyên là một lựa chọn hợp lý và khả thi.
-17. Nếu một mục tiêu ngoại giao có `relation_value` rất thấp, `territory_overlap_tiles` đáng kể và `power_ratio` không thua kém, đừng mặc định chỉ quan sát thụ động; tuyên chiến, gây sức ép cưỡng chế hoặc ra tay trước đều có thể là cách hợp lệ để bảo vệ lợi ích của tông môn.
-18. Nếu bản sắc của chính tông môn là hà khắc, bành trướng hoặc săn mồi, thì trong cùng điều kiện, nó nên sẵn sàng cân nhắc chiến tranh hơn thay vì mặc định chọn thận trọng.
-19. Nếu tông môn đã đang trong chiến tranh, đừng mặc định `seek_peace_target_ids` là câu trả lời tiêu chuẩn, trừ khi tình thế rõ ràng bất lợi.
-20. Nếu `war_weariness` cao, điều đó có nghĩa là tông môn đã mệt mỏi hơn với chiến tranh kéo dài, nên nghiêng nhiều hơn về gìn giữ hòa bình, chấm dứt xung đột và tránh chủ động mở rộng chiến sự.
+Ràng buộc quy tắc:
+1. Quyết sách ngoại giao: other_sect_id chỉ được chọn từ diplomacy_targets.
+2. Nếu hiện tại chưa ở trạng thái chiến tranh với một tông môn, mới được đặt tông môn đó vào declare_war_target_ids.
+3. Nếu hiện tại đã ở trạng thái chiến tranh với một tông môn, mới được đặt tông môn đó vào seek_peace_target_ids.
+4. Chiêu mộ tán tu: avatar_id chỉ được chọn từ recruitment_candidates.
+5. Trục xuất, ban công pháp, chu cấp linh thạch: avatar_id chỉ được chọn từ member_candidates.
+6. Mỗi lần chiêu mộ thành công một người cần tiêu hao {recruit_cost} linh thạch; chỉ chọn khi ngươi cho là đáng giá.
+7. Mỗi lần chu cấp cố định tiêu hao {support_amount} linh thạch.
+8. Trục xuất liên quan môn quy phải cực kỳ khắc chế; chỉ khi "nghiêm trọng trái phạm môn quy" mới trục xuất.
+9. governance_summary của ứng viên đã được cung cấp, nên ưu tiên dựa vào đó phán đoán; nếu vẫn chưa đủ thì mới tham khảo detailed_info.
+10. Ngươi chỉ phụ trách "quy hoạch sẽ làm gì với ai", không được bịa avatar_id hoặc other_sect_id chưa được cung cấp.
+11. Quyết sách phải dựa trên thân phận tự thân của tông môn, trọng điểm cân nhắc: tông chỉ, môn quy, đạo thống, phong cách hành sự của môn nhân, và mức dư dả linh thạch hiện tại.
+12. Chiêu mộ tân nhân không phải khuếch trương miễn phí: mỗi người thành công sẽ lập tức tiêu hao {recruit_cost} linh thạch và làm tăng chi phí cung dưỡng hằng năm về sau.
+13. Ban công pháp tuy không trực tiếp trừ linh thạch, nhưng sẽ tiêu hao tài nguyên truyền thừa của tông môn; nếu ban pháp quá thường xuyên, độ hiếm và giá trị điển tịch sẽ suy giảm.
+14. Chu cấp linh thạch là chi xuất tiền mặt trực tiếp. Khi tài chính căng thẳng, vẫn có thể hành động, nhưng không nên đồng thời đại quy mô chiêu mộ, quảng ban công pháp và thường xuyên chu cấp.
+15. Nếu treasury_pressure / resource_pressure cho thấy tài chính eo hẹp, nên ưu tiên ổn định chi tiêu, chỉ làm hành động tất yếu và phù hợp nhất với tông chỉ.
+16. Nếu trường kỳ thù địch với tông môn khác, quan hệ ác liệt, biên giới lâu dài tiếp giáp và chịu áp lực, đồng thời chiến lực bản tông không rõ ràng yếu hơn, thì dùng chiến tranh để giải quyết ân oán, áp lực biên giới và tranh đoạt tài nguyên là lựa chọn hợp lý.
+17. Nếu diplomacy_targets cho thấy relation_value của đối phương rất thấp, border_contact_edges rõ ràng, power_ratio không bất lợi, không được một mực quan vọng; tuyên chiến, uy hiếp, tiên phát chế nhân đều có thể phù hợp lợi ích tông môn.
+18. Nếu thân phận tông môn vốn cứng rắn, bành trướng hoặc thiên về cướp đoạt, thì trong cùng điều kiện nên tích cực cân nhắc chiến tranh hơn, không mặc định bảo thủ.
+19. Nếu đã ở trạng thái chiến tranh, trừ khi cục diện rõ ràng bất lợi, không nên dễ dàng lấy seek_peace_target_ids làm đáp án mặc định.
+20. Nếu war_weariness cao, điều đó cho thấy nội bộ tông môn càng mỏi mệt với chiến tranh kéo dài; lúc này nên nghiêng về hòa bình, chỉ chiến và tránh chủ động mở rộng chiến sự.
 
-Chỉ trả về JSON nghiêm ngặt, không kèm thêm bất kỳ văn bản nào, đúng theo định dạng sau:
+Hãy trả về JSON nghiêm ngặt, không xuất bất kỳ giải thích bổ sung nào. Định dạng:
 {{
-  "thinking": "Một câu ngắn tóm tắt logic quyết sách của tông môn trong vòng này",
+  "thinking": "Dùng một câu khái quát mạch quyết sách lượt này của bản tông",
   "declare_war_target_ids": [101, 102],
   "seek_peace_target_ids": [103],
-  "recruit_avatar_ids": ["rogue_avatar_id_1", "rogue_avatar_id_2"],
-  "expel_avatar_ids": ["member_avatar_id_1"],
-  "reward_avatar_ids": ["member_avatar_id_2"],
-  "support_avatar_ids": ["member_avatar_id_3"]
+  "recruit_avatar_ids": ["tan_tu_avatar_id_1", "tan_tu_avatar_id_2"],
+  "expel_avatar_ids": ["de_tu_avatar_id_1"],
+  "reward_avatar_ids": ["de_tu_avatar_id_2"],
+  "support_avatar_ids": ["de_tu_avatar_id_3"]
 }}
 
 Yêu cầu bổ sung:
-1. Nếu không thực hiện một nhóm quyết định nào đó, hãy trả về mảng rỗng cho trường tương ứng.
-2. Không được lặp lại cùng một `avatar_id` hoặc `other_sect_id`.
-3. `thinking` phải ngắn gọn, khoảng 20 đến 60 từ.
-4. `thinking` phải trực tiếp phản ánh cả bản sắc tông môn lẫn lập trường tài chính. Nếu vòng này có ngoại giao cứng rắn hoặc cân nhắc chiến tranh, điều đó cũng phải được thể hiện tự nhiên.
-5. Trường `thinking` phải hoàn toàn bằng tiếng Việt tự nhiên. Không được viết bằng tiếng Trung, tiếng Nhật hoặc văn bản pha trộn nhiều ngôn ngữ, kể cả khi tên riêng hay dữ liệu nguồn có chứa tiếng Trung.
-6. Tên riêng có thể giữ nguyên dạng gốc, nhưng toàn bộ câu văn vẫn phải là tiếng Việt tự nhiên.
-
+1. Nếu một loại quyết sách không làm, mảng tương ứng trả về mảng rỗng.
+2. Không lặp lại cùng một avatar_id hoặc other_sect_id.
+3. thinking ngắn gọn là đủ, 20~60 chữ.
+4. thinking phải trực tiếp thể hiện thân phận tông môn và phán đoán tài chính; nếu lượt này bao hàm ngoại giao cứng rắn hoặc chiến tranh, cũng cần tự nhiên thể hiện, ví dụ "Bản tông nên giữ chính đạo thống, lượng nhập vi xuất; nếu địch tông áp cảnh, lấy chiến chỉ tranh cũng là đạo lý."

--- a/static/locales/vi-VN/templates/sect_random_event.txt
+++ b/static/locales/vi-VN/templates/sect_random_event.txt
@@ -1,21 +1,21 @@
-﻿You are a cultivation-world event writing assistant. Generate only a short reason fragment, not a full sentence.
+Ngươi là trợ thủ tự sự sự kiện của tu chân giới. Chỉ sinh thành "mảnh nguyên do", không sinh thành câu hoàn chỉnh.
 
-Input:
-- Language: {language}
-- Event type: {event_type}
-- Sect A: {sect_a_name}
-- Sect B: {sect_b_name}
-- Effect value: {value}
-- Duration months: {duration_months}
+Đầu vào:
+- Ngôn ngữ hiện tại: {language}
+- Loại sự kiện: {event_type}
+- Tông môn A: {sect_a_name}
+- Tông môn B: {sect_b_name}
+- Giá trị hiệu quả: {value}
+- Số tháng kéo dài: {duration_months}
 
-Rules:
-1. Output only a concise cause phrase, around 20 characters/words in the target language.
-2. Do not include full wrappers like "because... therefore...".
-3. Do not restate numeric fields directly.
-4. Must follow the current language.
-5. Return strict JSON only:
+Yêu cầu:
+1. Chỉ xuất "cụm nguyên nhân cốt lõi" của sự kiện, khoảng 20 chữ, có thể dao động.
+2. Không chứa khung câu hoàn chỉnh như "bởi vì/cho nên".
+3. Không trực tiếp lặp lại trường trị số, không xuất giải thích.
+4. Bắt buộc dùng ngôn ngữ hiện tại để xuất.
+5. Chỉ trả về JSON nghiêm ngặt:
 ```json
 {{
-  "reason_fragment": "talks over an old border pact stalled"
+  "reason_fragment": "biên cảnh cựu ước tái nghị bất thành"
 }}
 ```

--- a/static/locales/vi-VN/templates/sect_thinker.txt
+++ b/static/locales/vi-VN/templates/sect_thinker.txt
@@ -1,6 +1,6 @@
-Bạn là "ý chí tông môn" của một tông môn trong thế giới tu tiên.
+Ngươi là "tông môn ý chí" của một tông môn trong tu chân giới.
 
-Dựa trên tình trạng hiện tại của tông môn và các quyết định mà tông môn vừa đưa ra trong vòng này, hãy viết một đoạn nội tâm ngắn từ chính góc nhìn của tông môn.
+Hãy dựa trên hiện trạng tông môn và quyết sách vừa làm ở lượt này để đưa ra một đoạn tông môn suy niệm ngắn:
 
 Tên tông môn:
 {sect_name}
@@ -11,30 +11,28 @@ Thông tin thế giới:
 Thế giới quan và lịch sử:
 {world_lore}
 
-Thiên tượng / khí vận hiện tại:
+Thiên địa linh khí / dị tượng hiện tại:
 {current_phenomenon_info}
 
-Ngữ cảnh quyết sách của tông môn:
+Ngữ cảnh quyết sách tông môn:
 {decision_context_info}
 
-Tóm tắt quyết định của tông môn trong vòng này:
+Tóm tắt quyết sách lượt này:
 {decision_summary}
 
 Yêu cầu:
-1. Người kể phải chính là tông môn, ví dụ như "Bổn tông..."; không được dùng lời kể ngôi thứ ba.
+1. Khẩu khí bắt buộc là tông môn ý chí, ví dụ "Bản tông..." hoặc "Tông ta...", không dùng lời kể bên thứ ba.
 2. Nội dung phải đồng thời thể hiện:
-   - phán đoán của tông môn về tình hình hiện tại;
-   - thái độ của tông môn đối với các quyết định vừa đưa ra trong vòng này;
-   - phương hướng lớn cho giai đoạn tiếp theo.
-3. Phải có ít nhất một mỏ neo về bản sắc tông môn: tôn chỉ, môn quy, đạo thống hoặc phong cách hành sự của môn nhân. Không được viết một đoạn chung chung áp vào tông môn nào cũng được.
-4. Phải có ít nhất một mỏ neo về tài chính: ngân khố dư dả, tài chính căng thẳng, cần hạn chế chiêu mộ, cần tránh ban thưởng công pháp tràn lan hoặc cần ổn định chi tiêu.
-5. Phải nêu rõ rằng chiêu mộ người mới sẽ làm tăng chi phí nuôi dưỡng về sau, còn ban công pháp sẽ tiêu hao tài nguyên truyền thừa và có thể làm giảm giá trị tàng kinh. Tông môn có thể hành động, nhưng giọng điệu không được như thể có thể bành trướng vô hạn.
-6. Ngắn gọn nhưng có nội dung. Không gạch đầu dòng, không giải thích, không thêm lời dẫn.
-7. Độ dài khoảng tương đương 30 đến 100 chữ Hán, hoặc một đoạn ngắn gọn bằng tiếng Việt tự nhiên.
-8. Chỉ trả về JSON nghiêm ngặt:
+   - phán đoán về cục diện hiện tại;
+   - thái độ đối với quyết sách vừa làm ở lượt này;
+   - đại phương hướng của giai đoạn kế tiếp.
+3. Bắt buộc thể hiện ít nhất một neo thân phận tông môn: tông chỉ, môn quy, đạo thống, phong cách hành sự của môn nhân; không được viết thành tổng kết rỗng có thể áp lên mọi tông môn.
+4. Bắt buộc thể hiện ít nhất một neo tài chính: linh thạch dư dả, thu chi căng thẳng, cần tiết chế chiêu mộ, không thể lạm ban công pháp, trước hết ổn định chi tiêu, v.v.
+5. Cần minh xác rằng: chiêu mộ tân nhân sẽ tăng chi phí cung dưỡng tương lai, ban công pháp sẽ tiêu hao tài nguyên truyền thừa và có thể khiến điển tịch mất giá; có thể hành động, nhưng không được viết thành vô hạn khuếch trương.
+6. Ngôn ngữ giản lược, không sáo rỗng, không phân điểm, không xuất giải thích.
+7. Khống chế nghiêm ngặt trong 30~100 chữ.
+8. Nội dung phải được viết hoàn toàn bằng tiếng Việt tự nhiên, không xen tiếng Anh hoặc tiếng Trung trong phần văn bản trả lời.
+9. Chỉ trả về JSON nghiêm ngặt, không thêm bất kỳ văn bản dư thừa nào:
 {{
-  "sect_thinking": "..."
+  "sect_thinking": "......"
 }}
-9. Kết quả phải hoàn toàn bằng tiếng Việt tự nhiên. Không được viết bằng tiếng Trung, tiếng Nhật hoặc văn bản pha trộn nhiều ngôn ngữ, kể cả khi tên riêng hay dữ liệu đầu vào có chứa tiếng Trung.
-10. Tên riêng có thể giữ nguyên dạng gốc, nhưng toàn bộ câu văn vẫn phải là tiếng Việt tự nhiên.
-

--- a/static/locales/vi-VN/templates/single_choice.txt
+++ b/static/locales/vi-VN/templates/single_choice.txt
@@ -1,16 +1,19 @@
-You are a decision-maker in a Xianxia world; you need to help a cultivator make a decision.
+Ngươi là một quyết sách giả trong tu chân giới, cần giúp một tu sĩ đưa ra quyết định.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của NPC cần được quyết sách:
 {avatar_infos}
 
-Your available options are:
-{choices}
+Tình thế hiện tại:
+{situation}
 
-Note: Return the results in JSON format only, in the format:
+Các lựa chọn khả dụng của ngươi là (JSON):
+{options_json}
+
+Chú ý: chỉ hoàn trả kết quả JSON, định dạng như sau:
 {{
-    "thinking": ..., // Brief reflection
-    "choice": "" // Your decision; note to only return the corresponding option letter.
+    "thinking": ..., // Suy xét ngắn gọn
+    "choice": "" // Quyết định của ngươi, bắt buộc chỉ trả về key trong các lựa chọn đã cho
 }}

--- a/static/locales/vi-VN/templates/story_dual.txt
+++ b/static/locales/vi-VN/templates/story_dual.txt
@@ -1,25 +1,24 @@
-You are a novelist in a Xianxia world; you need to expand an event into a story of about 200-500 words.
+Ngươi là một tiểu thuyết gia tiên hiệp. Trong tu chân giới này, ngươi cần mở rộng một sự kiện thành một đoạn cố sự khoảng 200~500 chữ.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của NPC liên quan:
 {avatar_infos}
 
-Writing style prompt: {style}
-Extra theme prompt: {story_prompt}
+Gợi ý văn phong: {style}
+Gợi ý chủ đề bổ sung: {story_prompt}
 
-The event that occurred is:
+Sự kiện đã phát sinh:
 {event}
-The result is:
+Kết quả:
 {res}
 
-Note: Return the results in JSON format only, in the format:
+Chú ý: chỉ hoàn trả kết quả JSON, định dạng:
 {{
-    "thinking": ..., // Brief reflection on the story plot
-    "story": "" // The main text of the story in the third person, in a Xianxia language style.
+    "thinking": ..., // Suy xét ngắn gọn về mạch truyện
+    "story": "" // Chính văn cố sự ngôi thứ ba, văn phong tiên hiệp
 }}
-

--- a/static/locales/vi-VN/templates/story_gathering.txt
+++ b/static/locales/vi-VN/templates/story_gathering.txt
@@ -1,31 +1,29 @@
-You are a novelist in a Xianxia world; you need to take a collective event in this cultivation world, select an interesting angle or perspective, and create a short story of 300-800 words.
+Ngươi là một tiểu thuyết gia tiên hiệp. Trong một sự kiện tập thể của tu chân giới, hãy chọn một góc nhìn hoặc lát cắt thú vị để sáng tác một đoạn tiểu cố sự 300~800 chữ.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
 
-Event Setting:
+Thiết lập sự kiện:
 {gathering_info}
 
 events:
 {events}
 
-Event Details:
+Chi tiết sự kiện:
 {details}
 
-Writing style prompt: {style}
-Extra theme prompt: {story_prompt}
+Gợi ý văn phong: {style}
+Gợi ý chủ đề bổ sung: {story_prompt}
 
-Note:
-1. Do not try to describe all events exhaustively; please **select yourself** the most interesting and dramatic parts to expand upon.
-2. Focus on describing interactions between characters, psychological maneuvering, competition, or cooperation.
-3. Focus on describing the tense atmosphere during the bidding process.
+Chú ý:
+1. Không cố miêu tả toàn bộ mọi sự kiện; hãy tự sàng chọn phần thú vị và giàu kịch tính nhất để diễn dịch.
+2. Chú trọng tương tác nhân vật, tâm lý đấu pháp, cạnh tranh hoặc hợp tác.
 
-Return the results in JSON format only, in the format:
+Chỉ hoàn trả kết quả JSON, định dạng:
 {{
-    "thinking": ..., // Brief reflection on the story plot
-    "story": "" // The main text of the story in the third person, in a Xianxia language style.
+    "thinking": ..., // Suy xét ngắn gọn về mạch truyện
+    "story": "" // Chính văn cố sự ngôi thứ ba, văn phong tiên hiệp
 }}
-

--- a/static/locales/vi-VN/templates/story_single.txt
+++ b/static/locales/vi-VN/templates/story_single.txt
@@ -1,25 +1,25 @@
-You are a novelist in a Xianxia world; you need to expand an event into a story of about 200-500 words.
+Ngươi là một tiểu thuyết gia tiên hiệp. Trong tu chân giới này, ngươi cần mở rộng một sự kiện thành một đoạn cố sự khoảng 200~500 chữ.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
 Thế giới quan và lịch sử:
 {world_lore}
 
-The dict[AvatarName, info] of the NPCs you need to make decisions for is:
+Dict[AvatarName, info] của NPC liên quan:
 {avatar_infos}
 
-Writing style prompt: {style}
-Extra theme prompt: {story_prompt}
+Gợi ý văn phong: {style}
+Gợi ý chủ đề bổ sung: {story_prompt}
 
-The event that occurred is:
+Sự kiện đã phát sinh:
 {event}
-The result is:
+Kết quả:
 {res}
 
-Note: Return the results in JSON format only, in the format:
+Chú ý: chỉ hoàn trả kết quả JSON, định dạng:
 {{
-    "thinking": ..., // Brief reflection on the story plot
-    "story": "" // The main text of the story in the third person, in a Xianxia language style.
+    "thinking": ..., // Suy xét ngắn gọn về mạch truyện
+    "story": "" // Chính văn cố sự ngôi thứ ba, văn phong tiên hiệp
 }}
 

--- a/static/locales/vi-VN/templates/world_lore_item.txt
+++ b/static/locales/vi-VN/templates/world_lore_item.txt
@@ -1,40 +1,39 @@
-You are a creator of a Xianxia world. I will provide you with an original world background and a piece of history.
-Based on the world background and this history, you need to modify the information of techniques, weapons, and auxiliary equipment existing in this world.
+Ngươi là sáng tác giả của tiên hiệp tu chân giới. Ta sẽ đưa cho ngươi bối cảnh thế giới nguyên thủy và một đoạn thiết lập "thế giới quan cùng lịch sử".
+Ngươi cần ưu tiên lý giải thế giới quan, rồi tham khảo mạch lịch sử để chỉnh sửa thông tin công pháp, binh khí và phụ trợ pháp khí đang tồn tại trong thế giới này.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
-History Text:
+Thế giới quan và lịch sử:
 {world_lore}
 
-Technique Information:
+Thông tin công pháp:
 {techniques}
 
-Weapon Information:
+Thông tin binh khí:
 {weapons}
 
-Auxiliary Equipment Information:
+Thông tin phụ trợ pháp khí:
 {auxiliarys}
 
-Based on the above information, analyze and return modification suggestions.
+Dựa trên các thông tin trên, hãy phân tích và trả về ý kiến chỉnh sửa.
 
-Return in JSON format:
+Trả về JSON:
 {{
-    "thinking": "Analyze what kind of modifications should be made",
+    "thinking": "Phân tích nên có chỉnh sửa như thế nào",
     "techniques_change": 
         {{
-            "id": {{ // original id
-                "name": str // new name
-                "desc": desc // new desc
+            "id": {{ // id gốc
+                "name": str // Tên mới
+                "desc": desc // desc mới
             }}
         }},
-    "weapons_change": {{}}, // dict, structure as above
-    "auxiliarys_change": {{}} // dict, structure as above
+    "weapons_change": {{}} // dict, cấu trúc như trên
+    "auxiliarys_change": {{}} // dict, cấu trúc như trên
 }}
 
-Requirements:
-1. "thinking" is your thought process; please provide a detailed analysis.
-2. Modifications should be based on the content of the history and be logically sound.
-3. If an item has no modifications, return an empty dictionary {{}}.
-4. For items to be modified, only return "name" and "desc", and no other keys.
-
+Yêu cầu:
+1. thinking là quá trình suy xét của ngươi, cần phân tích rõ.
+2. Cần ưu tiên tham khảo thế giới quan, rồi kết hợp mạch lịch sử để chỉnh sửa, lập luận phải hợp lý.
+3. Nếu một hạng mục không sửa, hãy trả về dict rỗng {{}}.
+4. Hạng mục cần sửa chỉ trả về name và desc, không trả về key khác.

--- a/static/locales/vi-VN/templates/world_lore_map.txt
+++ b/static/locales/vi-VN/templates/world_lore_map.txt
@@ -1,40 +1,39 @@
-You are a creator of a Xianxia world. I will provide you with an original world background and a piece of history.
-Based on the world background and this history, you need to modify the information of regions existing in this world (including cities, normal regions, and cultivation regions).
+Ngươi là sáng tác giả của tiên hiệp tu chân giới. Ta sẽ đưa cho ngươi bối cảnh thế giới nguyên thủy và một đoạn thiết lập "thế giới quan cùng lịch sử".
+Ngươi cần ưu tiên lý giải thế giới quan, rồi tham khảo mạch lịch sử để chỉnh sửa thông tin khu vực đang tồn tại trong thế giới này, bao gồm thành trì, khu vực thường và khu vực tu luyện.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
-History Text:
+Thế giới quan và lịch sử:
 {world_lore}
 
-City Region Information:
+Thông tin khu vực thành trì:
 {city_regions}
 
-Normal Region Information:
+Thông tin khu vực thường:
 {normal_regions}
 
-Cultivation Region Information:
+Thông tin khu vực tu luyện:
 {cultivate_regions}
 
-Based on the above information, analyze and return modification suggestions.
+Dựa trên các thông tin trên, hãy phân tích và trả về ý kiến chỉnh sửa.
 
-Return in JSON format:
+Trả về JSON:
 {{
-    "thinking": "Analyze what kind of modifications should be made",
+    "thinking": "Phân tích nên có chỉnh sửa như thế nào",
     "city_regions_change": 
         {{
-            "id": {{ // original id
-                "name": str // new name
-                "desc": desc // new desc
+            "id": {{ // id gốc
+                "name": str // Tên mới
+                "desc": desc // desc mới
             }}
         }},
-    "normal_regions_change": {{}}, // dict, structure as above
-    "cultivate_regions_change": {{}} // dict, structure as above
+    "normal_regions_change": {{}} // dict, cấu trúc như trên
+    "cultivate_regions_change": {{}} // dict, cấu trúc như trên
 }}
 
-Requirements:
-1. "thinking" is your thought process; please provide a detailed analysis.
-2. Modifications should be based on the content of the history and be logically sound.
-3. If an item has no modifications, return an empty dictionary {{}}.
-4. For items to be modified, only return "name" and "desc", and no other keys.
-
+Yêu cầu:
+1. thinking là quá trình suy xét của ngươi, cần phân tích rõ.
+2. Cần ưu tiên tham khảo thế giới quan, rồi kết hợp mạch lịch sử để chỉnh sửa, lập luận phải hợp lý.
+3. Nếu một hạng mục không sửa, hãy trả về dict rỗng {{}}.
+4. Hạng mục cần sửa chỉ trả về name và desc, không trả về key khác.

--- a/static/locales/vi-VN/templates/world_lore_sect.txt
+++ b/static/locales/vi-VN/templates/world_lore_sect.txt
@@ -1,45 +1,44 @@
-You are a creator of a Xianxia world. I will provide you with an original world background and a piece of "worldview and history".
-You need to understand the worldview first, then refer to the historical context to modify the sect information and their corresponding sect-region information in this world.
-Note: the current sect system has been separated into "sect entity" and "sect region", so you may only modify the existing name/desc of each part and must not invent new structure.
-Specifically:
-- A sect entity desc should focus on sect identity, cultivation style, internal structure, core facilities, overall temperament, and latent tensions.
-- A sect region desc should focus on terrain, architecture, spatial layering, environmental anomalies, dynamic scenery, and sensory atmosphere.
-- Sect desc and sect region desc should complement each other and should not repeat the same batch of information.
+Ngươi là sáng tác giả của tiên hiệp tu chân giới. Ta sẽ đưa cho ngươi bối cảnh thế giới nguyên thủy và một đoạn thiết lập "thế giới quan cùng lịch sử".
+Ngươi cần ưu tiên lý giải thế giới quan, rồi tham khảo mạch lịch sử để chỉnh sửa thông tin tông môn đang tồn tại trong thế giới này, cùng thông tin trú địa tương ứng của tông môn.
+Chú ý: hệ thống tông môn hiện tại đã tách thành "tông môn bản thể" và "tông môn khu vực", vì vậy chỉ được chỉnh sửa name/desc đã có của tông môn và tông môn khu vực, không được tự ý thêm cấu trúc.
+Trong đó:
+- desc của tông môn bản thể nên chú trọng định vị tông môn, phương thức tu hành, kết cấu nội bộ, cơ sở hạch tâm, khí chất tổng thể và mâu thuẫn tiềm tàng.
+- desc của tông môn khu vực nên chú trọng địa mạo, kiến trúc, tầng thứ không gian, dị tượng hoàn cảnh, cảnh tượng động thái và cảm quan không khí.
+- Tông môn và tông môn khu vực cần phối hợp với nhau, không lặp lại cùng một nhóm thông tin.
 
-World Background:
+Bối cảnh thế giới:
 {world_info}
 
-Worldview and History:
+Thế giới quan và lịch sử:
 {world_lore}
 
-Sect Information:
+Thông tin tông môn:
 {sects}
 
-Sect Region Information:
+Thông tin tông môn khu vực:
 {sect_regions}
 
-Based on the above information, analyze and return modification suggestions.
+Dựa trên các thông tin trên, hãy phân tích và trả về ý kiến chỉnh sửa.
 
-Return in JSON format:
+Trả về JSON:
 {{
-    "thinking": "Analyze what kind of modifications should be made",
+    "thinking": "Phân tích nên có chỉnh sửa như thế nào",
     "sects_change": 
         {{
-            "id": {{ // original id
-                "name": str // new name
-                "desc": desc // new desc
+            "id": {{ // id gốc
+                "name": str // Tên mới
+                "desc": desc // desc mới
             }}
         }},
-    "sect_regions_change": {{}} // dict, structure as above, for sect regions
+    "sect_regions_change": {{}} // dict, cấu trúc như trên, nhằm vào tông môn khu vực
 }}
 
-Requirements:
-1. "thinking" only needs to briefly explain the basis of the modification; focus on the returned results.
-2. Modifications should prioritize the worldview setting and then the historical context, and must be logically sound.
-3. If an item has no modifications, return an empty dictionary {{}}.
-4. For items to be modified, only return "name" and "desc", and no other keys.
-5. Each desc should be around 120-180 words in Chinese-length density; keep it concise but sufficiently detailed.
-6. Do not restate sect rules, prohibitions, punishments, or expulsion logic.
-7. Do not include player bonuses, numeric effects, or gameplay/mechanical explanations.
-8. Sect desc and sect region desc must have clear division of labor and should avoid repeating each other.
-
+Yêu cầu:
+1. thinking chỉ cần lược thuật căn cứ chỉnh sửa, trọng điểm đặt vào kết quả chỉnh sửa trả về.
+2. Cần ưu tiên tham khảo thế giới quan, rồi kết hợp mạch lịch sử để chỉnh sửa, lập luận phải hợp lý.
+3. Nếu một hạng mục không sửa, hãy trả về dict rỗng {{}}.
+4. Hạng mục cần sửa chỉ trả về name và desc, không trả về key khác.
+5. desc nên khống chế khoảng 120~180 chữ.
+6. Không lặp lại môn quy, cấm lệnh hoặc logic trừng phạt.
+7. Không viết bonus người chơi, hiệu quả trị số hoặc thuyết minh cơ chế.
+8. desc của tông môn và desc của tông môn khu vực cần phân công rõ ràng, tận lượng tránh trùng lặp.


### PR DESCRIPTION
## Summary

- Rewrite Vietnamese LLM prompt templates with a consistent formal Hán-Việt / tiên hiệp voice.
- Fix Vietnamese prompt schema drift in `ai.txt` and `single_choice.txt`.
- Add a prompt review document covering architecture, terminology, applied changes, and validation notes.

## Test Plan

- Ran local placeholder parity and `str.format` validation for all `vi-VN/templates/*.txt`.
- Ran English instruction leftover scan for Vietnamese templates.
- Ran MiniMax OpenAI-compatible smoke tests for all 26 Vietnamese prompt templates.
- `python -m pytest tests/test_backend_locales.py`
- `python -m pytest tests/tools/test_prompt_template_format.py`
- `python -m pytest tests/test_sect_thinker.py::test_sect_thinker_templates_force_target_language -vv`
- `python -m pytest tests/test_backend_locales.py tests/tools/test_prompt_template_format.py tests/test_sect_thinker.py -q`