### PR TITLE
fix(ai): stop NPCs from planning breakthrough before bottleneck

### DIFF
--- a/src/classes/action/breakthrough.py
+++ b/src/classes/action/breakthrough.py
@@ -42,6 +42,9 @@ class Breakthrough(TimedAction):
     IS_MAJOR: bool = True
     # 保留类级常量声明，实际读取模块级配置
 
+    def can_possibly_start(self) -> bool:
+        return self.avatar.cultivation_progress.can_break_through()
+
     def calc_success_rate(self) -> float:
         """
         计算突破境界的成功率（由修为进度给出）

--- a/tests/test_action_can_possibly_start.py
+++ b/tests/test_action_can_possibly_start.py
@@ -10,8 +10,11 @@ from src.classes.action.plunder_people import PlunderPeople
 from src.classes.action.help_people import HelpPeople
 from src.classes.action.catch import Catch
 from src.classes.action.sect_mission import SectMission
+from src.classes.action.breakthrough import Breakthrough
+from src.classes.actions import get_action_infos
 from src.classes.alignment import Alignment
 from src.classes.core.avatar import Avatar
+from src.systems.cultivation import CultivationProgress, REALM_ORDER, LEVELS_PER_REALM
 
 def test_respire_can_possibly_start(dummy_avatar, base_world):
     action = Respire(dummy_avatar, base_world)
@@ -143,3 +146,25 @@ def test_sect_mission_can_possibly_start(dummy_avatar, base_world):
     mock_sect.members = {}
     dummy_avatar.sect = mock_sect
     assert action.can_possibly_start() is True
+
+
+def test_breakthrough_can_possibly_start_only_at_valid_bottleneck(dummy_avatar, base_world):
+    action = Breakthrough(dummy_avatar, base_world)
+
+    dummy_avatar.cultivation_progress = CultivationProgress(level=15, exp=0)
+    assert action.can_possibly_start() is False
+
+    dummy_avatar.cultivation_progress = CultivationProgress(level=30, exp=0)
+    assert action.can_possibly_start() is True
+
+    max_level = len(REALM_ORDER) * LEVELS_PER_REALM
+    dummy_avatar.cultivation_progress = CultivationProgress(level=max_level, exp=0)
+    assert action.can_possibly_start() is False
+
+
+def test_action_infos_filters_breakthrough_when_avatar_cannot_break_through(dummy_avatar):
+    dummy_avatar.cultivation_progress = CultivationProgress(level=15, exp=0)
+    assert "Breakthrough" not in get_action_infos(dummy_avatar)
+
+    dummy_avatar.cultivation_progress = CultivationProgress(level=30, exp=0)
+    assert "Breakthrough" in get_action_infos(dummy_avatar)


### PR DESCRIPTION
## Summary

Hide `Breakthrough` from an avatar's available AI action list unless the avatar can actually break through.

## Motivation

`Breakthrough.can_start()` already rejects avatars that are not at a valid bottleneck. However, `get_action_infos(avatar)` filters the AI action space through `can_possibly_start()`, and `Breakthrough` inherited the default implementation that always returns `True`.

That means non-bottleneck NPCs can still see `Breakthrough` in their planning prompt, choose it, and only fail later during action commit. This creates avoidable invalid actions and wastes one planning slot for the avatar.

## Changes

- Added `Breakthrough.can_possibly_start()` and reused `cultivation_progress.can_break_through()` as the source of truth.
- Added coverage for:
  - non-bottleneck avatars not being eligible for `Breakthrough`
  - valid bottleneck avatars remaining eligible
  - max-realm avatars being filtered out
  - `get_action_infos(avatar)` excluding or including `Breakthrough` correctly

## Test Plan

```bash
CWS_DATA_DIR=/tmp/cws-test-data .venv/bin/python -m pytest tests/test_action_can_possibly_start.py -q
```

Result: `12 passed`

```bash
CWS_DATA_DIR=/tmp/cws-test-data .venv/bin/python -m pytest tests/test_action_can_possibly_start.py tests/test_breakthrough_logic.py -q
```

Result: `16 passed`

```bash
CWS_DATA_DIR=/tmp/cws-test-data .venv/bin/python -m pytest -q
```

Result: `1428 passed, 2 skipped`

## Risk

Low. This only affects whether `Breakthrough` is shown to the AI planner before an action is selected. The existing `can_start()` validation and breakthrough execution logic are unchanged.

The intended behavior is preserved for avatars that are actually at a valid breakthrough bottleneck.

## Related Context

Related to the invalid-action pattern described in #151, specifically NPCs attempting `Breakthrough` before reaching a bottleneck. This PR addresses only that narrow action-space filtering issue.
