### PR TITLE
Ground LLM action params in live world options

### DIFF
--- a/src/classes/action/param_options.py
+++ b/src/classes/action/param_options.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.classes.core.avatar import Avatar
+    from src.classes.environment.region import Region
+
+
+MAX_PARAM_OPTIONS = 20
+
+
+def build_param_options(action_cls: type, avatar: "Avatar") -> dict[str, list[dict[str, Any]]]:
+    params = getattr(action_cls, "PARAMS", {}) or {}
+    options: dict[str, list[dict[str, Any]]] = {}
+    for param_name, param_type in params.items():
+        param_options = _options_for_param(action_cls, avatar, param_name, param_type)
+        if param_options:
+            options[param_name] = param_options
+    return options
+
+
+def _options_for_param(action_cls: type, avatar: "Avatar", param_name: str, param_type: object) -> list[dict[str, Any]]:
+    action_name = action_cls.__name__
+    normalized_type = str(param_type).lower().replace(" ", "")
+
+    if action_name == "Buy" and param_name == "target_name":
+        return _store_item_options(avatar)
+    if action_name == "Sell" and param_name == "target_name":
+        return _sellable_item_options(avatar)
+    if action_name == "Gift" and param_name == "item_id":
+        return _gift_item_options(avatar)
+    if param_name in {"avatar_name", "target_avatar"} or "avatarname" in normalized_type:
+        return _avatar_options(avatar)
+    if param_name in {"region", "region_name"} or "regionname" in normalized_type or "region_name" in normalized_type:
+        return _known_region_options(avatar, cultivate_only=action_name == "Occupy")
+    if param_name == "target_realm":
+        return _realm_options_for_material_action(action_cls, avatar)
+    if param_name == "direction" or "direction" in normalized_type:
+        return _direction_options()
+    return []
+
+
+def _limit_options(options: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return options[:MAX_PARAM_OPTIONS]
+
+
+def _item_kind(item: object) -> str:
+    from src.classes.items.auxiliary import Auxiliary
+    from src.classes.items.elixir import Elixir
+    from src.classes.items.weapon import Weapon
+    from src.classes.material import Material
+
+    if isinstance(item, Elixir):
+        return "elixir"
+    if isinstance(item, Weapon):
+        return "weapon"
+    if isinstance(item, Auxiliary):
+        return "auxiliary"
+    if isinstance(item, Material):
+        return "material"
+    return type(item).__name__
+
+
+def _item_option(
+    item: object,
+    *,
+    price: int | None = None,
+    count: int | None = None,
+    source: str | None = None,
+) -> dict[str, Any]:
+    option: dict[str, Any] = {
+        "id": str(getattr(item, "id", "")),
+        "name": str(getattr(item, "name", "")),
+        "type": _item_kind(item),
+    }
+    realm = getattr(item, "realm", None)
+    if realm is not None:
+        option["realm"] = str(realm)
+        option["realm_id"] = str(getattr(realm, "value", realm))
+    if price is not None:
+        option["price"] = int(price)
+    if count is not None:
+        option["count"] = int(count)
+    if source is not None:
+        option["source"] = source
+    return option
+
+
+def _store_item_options(avatar: "Avatar") -> list[dict[str, Any]]:
+    from src.classes.prices import prices
+
+    region = getattr(getattr(avatar, "tile", None), "region", None)
+    store_items = list(getattr(region, "store_items", []) or [])
+    options = []
+    for item in store_items:
+        options.append(_item_option(item, price=prices.get_buying_price(item, avatar), source="current_city_store"))
+    return _limit_options(options)
+
+
+def _sellable_item_options(avatar: "Avatar") -> list[dict[str, Any]]:
+    options: list[dict[str, Any]] = []
+    for material, count in getattr(avatar, "materials", {}).items():
+        if int(count) > 0:
+            options.append(_item_option(material, count=int(count), source="inventory"))
+
+    weapon = getattr(avatar, "weapon", None)
+    if weapon is not None:
+        options.append(_item_option(weapon, source="equipped_weapon"))
+
+    auxiliary = getattr(avatar, "auxiliary", None)
+    if auxiliary is not None:
+        options.append(_item_option(auxiliary, source="equipped_auxiliary"))
+
+    return _limit_options(options)
+
+
+def _gift_item_options(avatar: "Avatar") -> list[dict[str, Any]]:
+    options: list[dict[str, Any]] = []
+    magic_stone = getattr(avatar, "magic_stone", 0)
+    stone_amount = int(getattr(magic_stone, "value", magic_stone) or 0)
+    if stone_amount > 0:
+        from src.i18n import t
+
+        options.append({
+            "id": "SPIRIT_STONE",
+            "name": t("spirit stones"),
+            "type": "spirit_stone",
+            "max_amount": stone_amount,
+        })
+
+    for material, count in getattr(avatar, "materials", {}).items():
+        if int(count) > 0:
+            options.append(_item_option(material, count=int(count), source="inventory"))
+
+    weapon = getattr(avatar, "weapon", None)
+    if weapon is not None:
+        options.append(_item_option(weapon, source="equipped_weapon"))
+
+    auxiliary = getattr(avatar, "auxiliary", None)
+    if auxiliary is not None:
+        options.append(_item_option(auxiliary, source="equipped_auxiliary"))
+
+    return _limit_options(options)
+
+
+def _avatar_options(avatar: "Avatar") -> list[dict[str, Any]]:
+    world = getattr(avatar, "world", None)
+    manager = getattr(world, "avatar_manager", None)
+    if manager is None:
+        return []
+
+    candidates = []
+    if hasattr(manager, "get_observable_avatars"):
+        candidates = manager.get_observable_avatars(avatar)
+    if not candidates and hasattr(manager, "get_living_avatars"):
+        candidates = [item for item in manager.get_living_avatars() if item is not avatar]
+
+    options = []
+    for other in candidates:
+        if other is avatar or getattr(other, "is_dead", False):
+            continue
+        option = {
+            "id": str(getattr(other, "id", "")),
+            "name": str(getattr(other, "name", "")),
+            "realm": str(getattr(getattr(other, "cultivation_progress", None), "get_info", lambda: "")()),
+        }
+        sect = getattr(other, "sect", None)
+        if sect is not None:
+            option["sect"] = str(getattr(sect, "name", ""))
+        options.append(option)
+    return _limit_options(options)
+
+
+def _known_region_options(avatar: "Avatar", *, cultivate_only: bool = False) -> list[dict[str, Any]]:
+    from src.classes.environment.region import CultivateRegion
+
+    world = getattr(avatar, "world", None)
+    game_map = getattr(world, "map", None)
+    regions = list(getattr(game_map, "regions", {}).values())
+    known_regions = getattr(avatar, "known_regions", None)
+
+    options = []
+    for region in regions:
+        if known_regions is not None and region.id not in known_regions:
+            continue
+        if cultivate_only and not isinstance(region, CultivateRegion):
+            continue
+        if cultivate_only and getattr(region, "host_avatar", None) is avatar:
+            continue
+        options.append(_region_option(region))
+    return _limit_options(options)
+
+
+def _region_option(region: "Region") -> dict[str, Any]:
+    return {
+        "id": str(getattr(region, "id", "")),
+        "name": str(getattr(region, "name", "")),
+        "type": str(region.get_region_type() if hasattr(region, "get_region_type") else type(region).__name__),
+    }
+
+
+def _realm_options_for_material_action(action_cls: type, avatar: "Avatar") -> list[dict[str, Any]]:
+    from src.systems.cultivation import Realm
+
+    cost = int(getattr(action_cls, "COST", 0) or 0)
+    counts = {realm: 0 for realm in Realm}
+    for material, qty in getattr(avatar, "materials", {}).items():
+        realm = getattr(material, "realm", None)
+        if realm in counts:
+            counts[realm] += int(qty)
+
+    options = []
+    for realm, count in counts.items():
+        if cost > 0 and count < cost:
+            continue
+        options.append({
+            "id": realm.value,
+            "name": str(realm),
+            "material_count": count,
+            "required_material_count": cost,
+        })
+    return _limit_options(options)
+
+
+def _direction_options() -> list[dict[str, Any]]:
+    return [
+        {"id": "north", "name": "north"},
+        {"id": "south", "name": "south"},
+        {"id": "east", "name": "east"},
+        {"id": "west", "name": "west"},
+    ]

--- a/src/classes/actions.py
+++ b/src/classes/actions.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from src.classes.core.avatar import Avatar
 
 from src.classes.action.registry import ActionRegistry
+from src.classes.action.param_options import build_param_options
 # 确保在收集注册表前加载所有动作模块（含 mutual actions）
 import src.classes.action  # noqa: F401
 import src.classes.mutual_action  # noqa: F401
@@ -17,13 +18,18 @@ ALL_ACTUAL_ACTION_CLASSES = list(ActionRegistry.all_actual())
 ALL_ACTION_NAMES = [cls.__name__ for cls in ALL_ACTION_CLASSES]
 ALL_ACTUAL_ACTION_NAMES = [cls.__name__ for cls in ALL_ACTUAL_ACTION_CLASSES]
 
-def _build_action_info(action):
+
+def _build_action_info(action, avatar: "Avatar" | None = None):
     info = {
         "desc": action.get_desc(),
         "require": action.get_requirements(),
     }
     if hasattr(action, 'PARAMS') and action.PARAMS:
         info["params"] = action.PARAMS
+        if avatar is not None:
+            param_options = build_param_options(action, avatar)
+            if param_options:
+                info["param_options"] = param_options
 
     cd = int(getattr(action, "ACTION_CD_MONTHS", 0) or 0)
     if cd > 0:
@@ -42,7 +48,7 @@ def get_action_infos(avatar: "Avatar" | None = None) -> Dict[str, Any]:
             action_inst = action_cls(avatar, avatar.world)
             if not action_inst.can_possibly_start():
                 continue
-        infos[action_cls.__name__] = _build_action_info(action_cls)
+        infos[action_cls.__name__] = _build_action_info(action_cls, avatar=avatar)
     return infos
 
 def get_action_infos_str(avatar: "Avatar" | None = None) -> str:

--- a/tests/test_action_param_options.py
+++ b/tests/test_action_param_options.py
@@ -1,0 +1,159 @@
+from src.classes.actions import get_action_infos
+from src.classes.age import Age
+from src.classes.core.avatar import Avatar, Gender
+from src.classes.environment.region import CityRegion, CultivateRegion
+from src.classes.environment.tile import Tile, TileType
+from src.classes.root import Root
+from src.systems.cultivation import Realm
+from src.systems.time import Month, Year, create_month_stamp
+from src.utils.id_generator import get_avatar_id
+from tests.conftest import create_test_weapon
+
+
+def _names(options: list[dict]) -> set[str]:
+    return {str(option.get("name", "")) for option in options}
+
+
+def _ids(options: list[dict]) -> set[str]:
+    return {str(option.get("id", "")) for option in options}
+
+
+def _register_nearby_avatar(base_world, avatar_in_city) -> Avatar:
+    target = Avatar(
+        world=base_world,
+        name="NearbyNPC",
+        id=get_avatar_id(),
+        birth_month_stamp=create_month_stamp(Year(2000), Month.JANUARY),
+        age=Age(20, Realm.Qi_Refinement),
+        gender=Gender.FEMALE,
+        pos_x=0,
+        pos_y=0,
+        root=Root.WOOD,
+        personas=[],
+    )
+    target.tile = avatar_in_city.tile
+    base_world.avatar_manager.register_avatar(avatar_in_city)
+    base_world.avatar_manager.register_avatar(target)
+    return target
+
+
+def test_action_infos_expose_contextual_param_options(
+    avatar_in_city,
+    base_world,
+    mock_item_data,
+):
+    city = avatar_in_city.tile.region
+    city.store_items = [
+        mock_item_data["obj_elixir"],
+        mock_item_data["obj_weapon"],
+        mock_item_data["obj_material"],
+    ]
+    base_world.map.regions[city.id] = city
+    avatar_in_city.known_regions.add(city.id)
+
+    cave = CultivateRegion(id=2, name="青云洞府", desc="灵气充盈", cors=[(1, 1)])
+    base_world.map.regions[cave.id] = cave
+    avatar_in_city.known_regions.add(cave.id)
+
+    avatar_in_city.add_material(mock_item_data["obj_material"], quantity=5)
+    avatar_in_city.weapon = mock_item_data["obj_weapon"]
+    avatar_in_city.auxiliary = mock_item_data["obj_auxiliary"]
+    _register_nearby_avatar(base_world, avatar_in_city)
+
+    infos = get_action_infos(avatar_in_city)
+
+    buy_options = infos["Buy"]["param_options"]["target_name"]
+    assert {"聚气丹", "青云剑", "铁矿石"} <= _names(buy_options)
+    assert all("price" in option for option in buy_options)
+
+    sell_options = infos["Sell"]["param_options"]["target_name"]
+    assert {"铁矿石", "青云剑", "聚灵珠"} <= _names(sell_options)
+
+    gift_options = infos["Gift"]["param_options"]["item_id"]
+    assert {"SPIRIT_STONE", str(mock_item_data["obj_material"].id), str(mock_item_data["obj_weapon"].id)} <= _ids(gift_options)
+    assert str(mock_item_data["obj_elixir"].id) not in _ids(gift_options)
+
+    target_options = infos["Talk"]["param_options"]["target_avatar"]
+    assert "NearbyNPC" in _names(target_options)
+
+    region_options = infos["MoveToRegion"]["param_options"]["region"]
+    assert {"TestCity", "青云洞府"} <= _names(region_options)
+
+    occupy_options = infos["Occupy"]["param_options"]["region_name"]
+    assert "青云洞府" in _names(occupy_options)
+    assert "TestCity" not in _names(occupy_options)
+
+    direction_options = infos["MoveToDirection"]["param_options"]["direction"]
+    assert {"north", "south", "east", "west"} <= _ids(direction_options)
+
+    cast_realms = infos["Cast"]["param_options"]["target_realm"]
+    refine_realms = infos["Refine"]["param_options"]["target_realm"]
+    assert Realm.Qi_Refinement.value in _ids(cast_realms)
+    assert Realm.Qi_Refinement.value in _ids(refine_realms)
+
+
+def test_action_param_options_are_derived_from_live_world_state(
+    avatar_in_city,
+    base_world,
+    mock_item_data,
+):
+    city = avatar_in_city.tile.region
+    city.store_items = [mock_item_data["obj_elixir"]]
+    base_world.map.regions[city.id] = city
+    avatar_in_city.known_regions.add(city.id)
+
+    before = get_action_infos(avatar_in_city)
+    assert "玄铁剑" not in _names(before["Buy"]["param_options"]["target_name"])
+
+    city.store_items.append(create_test_weapon("玄铁剑", Realm.Qi_Refinement, weapon_id=90210))
+
+    after = get_action_infos(avatar_in_city)
+    assert "玄铁剑" in _names(after["Buy"]["param_options"]["target_name"])
+
+
+def test_contextual_action_parameters_are_grounded_or_left_numeric(
+    avatar_in_city,
+    base_world,
+    mock_item_data,
+):
+    city = avatar_in_city.tile.region
+    city.store_items = [mock_item_data["obj_elixir"], mock_item_data["obj_material"]]
+    base_world.map.regions[city.id] = city
+    avatar_in_city.known_regions.add(city.id)
+    cave = CultivateRegion(id=2, name="青云洞府", desc="灵气充盈", cors=[(1, 1)])
+    base_world.map.regions[cave.id] = cave
+    avatar_in_city.known_regions.add(cave.id)
+    avatar_in_city.add_material(mock_item_data["obj_material"], quantity=5)
+    _register_nearby_avatar(base_world, avatar_in_city)
+
+    infos = get_action_infos(avatar_in_city)
+    grounded_param_names = {
+        "avatar_name",
+        "target_avatar",
+        "region",
+        "region_name",
+        "target_name",
+        "item_id",
+        "target_realm",
+        "direction",
+    }
+    grounded_param_types = {
+        "avatarname",
+        "regionname",
+        "region_name",
+        "direction",
+    }
+
+    for action_name, info in infos.items():
+        params = info.get("params", {})
+        for param_name, param_type in params.items():
+            normalized_type = str(param_type).lower().replace(" ", "")
+            needs_grounding = (
+                param_name in grounded_param_names
+                or any(kind in normalized_type for kind in grounded_param_types)
+            )
+            if not needs_grounding:
+                continue
+
+            options = info.get("param_options", {}).get(param_name)
+            assert options, f"{action_name}.{param_name} should expose contextual options"


### PR DESCRIPTION
## Summary

Expose contextual `param_options` in `get_action_infos(avatar)` so LLM action planning can choose from live, valid world-state candidates instead of guessing free-form parameter values.

## Motivation

Several action parameters are names or IDs that only make sense in the current game state: store items, inventory items, nearby avatars, known regions, occupy-able regions, directions, and material realms.

Before this change, the action schema described the required parameter shape, but did not provide the current valid candidates. That makes it easy for the model to produce plausible-looking but invalid values, especially for actions like `Buy`, `Sell`, `Gift`, `Talk`, `MoveToRegion`, `Occupy`, `Cast`, and `Refine`.

## Changes

- Adds a dedicated action parameter option builder.
- Adds contextual `param_options` only when an avatar is available.
- Derives options from live world state instead of a separate static pool:
  - current city store items for `Buy`
  - inventory/equipment for `Sell`
  - giftable stones/materials/equipment for `Gift`
  - observable avatars for social actions
  - known regions for movement
  - known cultivate regions for `Occupy`
  - available material realms for `Cast` and `Refine`
  - fixed cardinal directions for directional movement
- Keeps the static import-time `ACTION_INFOS` snapshot unchanged for compatibility.

## Test Plan

- `CWS_DATA_DIR=/private/tmp/cws-test .venv/bin/python -m pytest -q`
  - `1433 passed, 2 skipped`
- `CWS_DATA_DIR=/private/tmp/cws-test .venv/bin/python -m pytest -v --cov=src --cov-report=xml --cov-report=term --cov-fail-under=60`
  - `1433 passed, 2 skipped`
  - Total coverage: `75.66%`
- `CWS_DATA_DIR=/private/tmp/cws-test .venv/bin/python -m py_compile src/classes/actions.py src/classes/action/param_options.py tests/test_action_param_options.py`
- `git diff --check`

## Risk

Low to moderate. This changes the prompt payload generated for avatar-specific action info, but does not change action execution logic. The new options are capped to avoid unbounded prompt growth and are omitted when no contextual candidates exist.
