### PR TITLE
feat(sim): make public predation ripple through nearby NPCs

### DIFF
--- a/src/classes/action/eat_mortals.py
+++ b/src/classes/action/eat_mortals.py
@@ -5,6 +5,7 @@ from src.classes.action import TimedAction
 from src.classes.event import Event
 from src.classes.alignment import Alignment
 from src.classes.environment.region import CityRegion
+from src.classes.public_event_reaction_service import PUBLIC_PREDATION_EVENT_TYPE
 from src.classes.race import is_yao_avatar
 from src.systems.cultivation import REALM_RANK
 
@@ -70,5 +71,14 @@ class EatMortals(TimedAction):
                 t("{avatar} ate {count} mortals in {city}, refining flesh and fear into {exp} cultivation experience.", avatar=self.avatar.name, count=eaten_people, city=region.name, exp=exp),
                 related_avatars=[self.avatar.id],
                 is_major=True,
+                event_type=PUBLIC_PREDATION_EVENT_TYPE,
+                render_params={
+                    "predator_id": str(self.avatar.id),
+                    "predator_name": self.avatar.name,
+                    "subject_name": self.avatar.name,
+                    "city_name": region.name,
+                    "eaten_count": eaten_people,
+                    "exp": exp,
+                },
             )
         ]

--- a/src/classes/event_renderer.py
+++ b/src/classes/event_renderer.py
@@ -34,6 +34,15 @@ def render_observed_event(event: "Event", observation_row) -> str:
         bond_label = t(str(params.get("bond_label_id") or "bond_label_major_relationship"))
         return t("You learned that {subject_name} and {other_name} {bond_label}.", subject_name=subject_name, other_name=other_name, bond_label=bond_label)
 
+    if propagation_kind == "local_witness_public_predation":
+        predator_name = str(params.get("predator_name") or subject_name)
+        city_name = str(params.get("city_name") or t("Somewhere"))
+        return t(
+            "You witnessed {predator_name} devouring mortals in {city_name}.",
+            predator_name=predator_name,
+            city_name=city_name,
+        )
+
     if propagation_kind == "close_relation_major":
         if event.content:
             return t("You learned that {subject_name} experienced a major event: {content}", subject_name=subject_name, content=event.content)

--- a/src/classes/public_event_reaction_service.py
+++ b/src/classes/public_event_reaction_service.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.classes.alignment import Alignment
+from src.classes.emotions import EmotionType
+from src.classes.environment.region import CityRegion
+from src.classes.event_observation import EventObservation
+from src.classes.observe import is_within_observation
+from src.systems.battle import get_base_strength
+
+if TYPE_CHECKING:
+    from src.classes.core.avatar import Avatar
+    from src.classes.core.world import World
+    from src.classes.event import Event
+
+
+PUBLIC_PREDATION_EVENT_TYPE = "public_predation"
+LOCAL_WITNESS_PUBLIC_PREDATION = "local_witness_public_predation"
+PUBLIC_PREDATION_MAX_RESPONDERS = 1
+
+
+def apply_public_event_reactions(event: "Event", world: "World") -> None:
+    if event.event_type != PUBLIC_PREDATION_EVENT_TYPE or event.is_story:
+        return
+
+    predator = _resolve_predator(event, world)
+    if predator is None or getattr(predator, "is_dead", False):
+        return
+
+    params = dict(event.render_params or {})
+    params.setdefault("predator_id", str(predator.id))
+    params.setdefault("predator_name", predator.name)
+    params.setdefault("subject_name", predator.name)
+    region = getattr(getattr(predator, "tile", None), "region", None)
+    if region is not None:
+        params.setdefault("city_name", str(getattr(region, "name", "")))
+    event.render_params = params
+
+    response_candidates: list["Avatar"] = []
+    for observer in world.avatar_manager.get_living_avatars():
+        if observer is predator or getattr(observer, "is_dead", False):
+            continue
+        if not _can_observe_public_predation(observer, predator):
+            continue
+
+        _append_witness_observation(event, observer, predator)
+        if _apply_witness_emotion(observer, predator):
+            response_candidates.append(observer)
+
+    for responder in _select_response_candidates(response_candidates)[:PUBLIC_PREDATION_MAX_RESPONDERS]:
+        _queue_public_predation_response(responder, predator)
+
+
+def _resolve_predator(event: "Event", world: "World") -> "Avatar | None":
+    predator_id = str((event.render_params or {}).get("predator_id") or "")
+    if not predator_id and event.related_avatars:
+        predator_id = str(event.related_avatars[0])
+    if not predator_id:
+        return None
+    return world.avatar_manager.get_avatar(predator_id)
+
+
+def _can_observe_public_predation(observer: "Avatar", predator: "Avatar") -> bool:
+    observer_region = getattr(getattr(observer, "tile", None), "region", None)
+    predator_region = getattr(getattr(predator, "tile", None), "region", None)
+    if isinstance(predator_region, CityRegion) and observer_region == predator_region:
+        return True
+    return is_within_observation(observer, predator)
+
+
+def _append_witness_observation(event: "Event", observer: "Avatar", predator: "Avatar") -> None:
+    observer_id = str(observer.id)
+    if observer_id in {str(item) for item in (event.related_avatars or [])}:
+        return
+
+    existing_keys = {
+        (str(getattr(obs, "observer_avatar_id", "")), str(getattr(obs, "propagation_kind", "")))
+        for obs in getattr(event, "observations", []) or []
+    }
+    key = (observer_id, LOCAL_WITNESS_PUBLIC_PREDATION)
+    if key in existing_keys:
+        return
+
+    event.observations.append(
+        EventObservation(
+            observer_avatar_id=observer_id,
+            subject_avatar_id=str(predator.id),
+            propagation_kind=LOCAL_WITNESS_PUBLIC_PREDATION,
+        )
+    )
+
+
+def _apply_witness_emotion(observer: "Avatar", predator: "Avatar") -> bool:
+    alignment = getattr(observer, "alignment", None)
+    if alignment == Alignment.EVIL:
+        return False
+
+    observer_strength = get_base_strength(observer)
+    predator_strength = get_base_strength(predator)
+    can_confront = alignment == Alignment.RIGHTEOUS and observer_strength >= predator_strength
+
+    observer.emotion = EmotionType.ANGRY if can_confront else EmotionType.FEARFUL
+    if not can_confront:
+        return False
+    return observer.current_action is None and not observer.has_plans()
+
+
+def _select_response_candidates(candidates: list["Avatar"]) -> list["Avatar"]:
+    return sorted(
+        candidates,
+        key=lambda avatar: (
+            -get_base_strength(avatar),
+            str(getattr(avatar, "name", "")),
+            str(getattr(avatar, "id", "")),
+        ),
+    )
+
+
+def _queue_public_predation_response(observer: "Avatar", predator: "Avatar") -> None:
+    observer.load_decide_result_chain(
+        [
+            ("MoveToAvatar", {"avatar_name": predator.name}),
+            ("Attack", {"avatar_name": predator.name}),
+        ],
+        observer.thinking,
+        f"Stop {predator.name} after witnessing public predation.",
+    )

--- a/src/sim/simulator_engine/finalizer.py
+++ b/src/sim/simulator_engine/finalizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from src.classes.event import Event
 from src.classes.close_relation_event_service import append_close_relation_major_observations
+from src.classes.public_event_reaction_service import apply_public_event_reactions
 from src.run.log import get_logger
 
 from .context import SimulationStepContext
@@ -31,6 +32,7 @@ def finalize_step(ctx: SimulationStepContext) -> list[Event]:
         "bond_master_disciple_formed",
     }
     for event in final_events:
+        apply_public_event_reactions(event, ctx.world)
         if not event.is_major or event.is_story or event.event_type in special_major_kinds:
             continue
         for avatar_id in event.related_avatars or []:

--- a/static/locales/en-US/LC_MESSAGES/messages.po
+++ b/static/locales/en-US/LC_MESSAGES/messages.po
@@ -1433,6 +1433,9 @@ msgstr "House {surname}"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "Action on cooldown, {remain} month(s) remaining"
 
+msgid "Somewhere"
+msgstr "Somewhere"
+
 msgid ""
 "Focus on governance affairs, malevolent incidents, local strongmen, and "
 "political rivals creating obstacles."
@@ -3294,6 +3297,9 @@ msgstr "You learned that {subject_name} was killed by {killer_name}."
 
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "You learned that {subject_name} and {other_name} {bond_label}."
+
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "You witnessed {predator_name} devouring mortals in {city_name}."
 
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "You learned that {subject_name} experienced a major event: {content}"

--- a/static/locales/en-US/modules/common.po
+++ b/static/locales/en-US/modules/common.po
@@ -257,5 +257,8 @@ msgstr "House {surname}"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "Action on cooldown, {remain} month(s) remaining"
 
+msgid "Somewhere"
+msgstr "Somewhere"
+
 msgid "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."
 msgstr "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."

--- a/static/locales/en-US/modules/relation.po
+++ b/static/locales/en-US/modules/relation.po
@@ -202,6 +202,9 @@ msgstr "You learned that {subject_name} was killed by {killer_name}."
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "You learned that {subject_name} and {other_name} {bond_label}."
 
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "You witnessed {predator_name} devouring mortals in {city_name}."
+
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "You learned that {subject_name} experienced a major event: {content}"
 

--- a/static/locales/ja-JP/LC_MESSAGES/messages.po
+++ b/static/locales/ja-JP/LC_MESSAGES/messages.po
@@ -1336,6 +1336,9 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "クールダウン中。あと {remain} か月必要"
 
+msgid "Somewhere"
+msgstr "どこか"
+
 msgid ""
 "Focus on governance affairs, malevolent incidents, local strongmen, and "
 "political rivals creating obstacles."
@@ -3091,6 +3094,9 @@ msgstr "{subject_name} が {killer_name} に殺されたと知った。"
 
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "{subject_name} と {other_name} が {bond_label} と知った。"
+
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "{predator_name} が {city_name} で凡人を貪るのを目撃した。"
 
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "{subject_name} が大きな出来事を経験したと知った: {content}"

--- a/static/locales/ja-JP/modules/common.po
+++ b/static/locales/ja-JP/modules/common.po
@@ -256,5 +256,8 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "クールダウン中。あと {remain} か月必要"
 
+msgid "Somewhere"
+msgstr "どこか"
+
 msgid "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."
 msgstr "政務処理、邪異との遭遇、地方豪強、政敵の妨害を中心に描写すること。"

--- a/static/locales/ja-JP/modules/relation.po
+++ b/static/locales/ja-JP/modules/relation.po
@@ -192,6 +192,9 @@ msgstr "{subject_name} が {killer_name} に殺されたと知った。"
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "{subject_name} と {other_name} が {bond_label} と知った。"
 
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "{predator_name} が {city_name} で凡人を貪るのを目撃した。"
+
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "{subject_name} が大きな出来事を経験したと知った: {content}"
 

--- a/static/locales/vi-VN/LC_MESSAGES/messages.po
+++ b/static/locales/vi-VN/LC_MESSAGES/messages.po
@@ -1436,6 +1436,9 @@ msgstr "Hoàng tộc {surname}"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "Hành động đang hồi chiêu, còn {remain} tháng"
 
+msgid "Somewhere"
+msgstr "Một nơi nào đó"
+
 msgid ""
 "Focus on governance affairs, malevolent incidents, local strongmen, and "
 "political rivals creating obstacles."
@@ -3307,6 +3310,9 @@ msgstr "Ngươi biết rằng {subject_name} đã bị {killer_name} sát hại.
 
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "Ngươi biết rằng {subject_name} và {other_name} {bond_label}."
+
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "Ngươi chứng kiến {predator_name} nuốt chửng phàm nhân ở {city_name}."
 
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "Ngươi biết rằng {subject_name} đã trải qua một đại sự: {content}"

--- a/static/locales/vi-VN/modules/common.po
+++ b/static/locales/vi-VN/modules/common.po
@@ -256,5 +256,8 @@ msgstr "Hoàng tộc {surname}"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "Hành động đang hồi chiêu, còn {remain} tháng"
 
+msgid "Somewhere"
+msgstr "Một nơi nào đó"
+
 msgid "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."
 msgstr "Tập trung vào việc xử lý chính vụ, tà họa, hào cường địa phương và đối thủ chính trị gây trở ngại."

--- a/static/locales/vi-VN/modules/relation.po
+++ b/static/locales/vi-VN/modules/relation.po
@@ -202,6 +202,9 @@ msgstr "Ngươi biết rằng {subject_name} đã bị {killer_name} sát hại.
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "Ngươi biết rằng {subject_name} và {other_name} {bond_label}."
 
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "Ngươi chứng kiến {predator_name} nuốt chửng phàm nhân ở {city_name}."
+
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "Ngươi biết rằng {subject_name} đã trải qua một đại sự: {content}"
 

--- a/static/locales/zh-CN/LC_MESSAGES/messages.po
+++ b/static/locales/zh-CN/LC_MESSAGES/messages.po
@@ -1338,6 +1338,9 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "冷却中，还需 {remain} 个月"
 
+msgid "Somewhere"
+msgstr "某处"
+
 msgid ""
 "Focus on governance affairs, malevolent incidents, local strongmen, and "
 "political rivals creating obstacles."
@@ -3080,6 +3083,9 @@ msgstr "你得知 {subject_name} 被 {killer_name} 杀害。"
 
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "你得知 {subject_name} 与 {other_name}{bond_label}。"
+
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "你目睹 {predator_name} 在 {city_name} 吞食凡人。"
 
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "你得知 {subject_name} 发生了一件大事：{content}"

--- a/static/locales/zh-CN/modules/common.po
+++ b/static/locales/zh-CN/modules/common.po
@@ -253,5 +253,8 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "冷却中，还需 {remain} 个月"
 
+msgid "Somewhere"
+msgstr "某处"
+
 msgid "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."
 msgstr "主题围绕处理政务、遭遇邪祟、地方豪强、政敌掣肘展开。"

--- a/static/locales/zh-CN/modules/relation.po
+++ b/static/locales/zh-CN/modules/relation.po
@@ -183,6 +183,9 @@ msgstr "你得知 {subject_name} 被 {killer_name} 杀害。"
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "你得知 {subject_name} 与 {other_name}{bond_label}。"
 
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "你目睹 {predator_name} 在 {city_name} 吞食凡人。"
+
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "你得知 {subject_name} 发生了一件大事：{content}"
 

--- a/static/locales/zh-TW/LC_MESSAGES/messages.po
+++ b/static/locales/zh-TW/LC_MESSAGES/messages.po
@@ -1337,6 +1337,9 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "冷卻中，還需 {remain} 個月"
 
+msgid "Somewhere"
+msgstr "某處"
+
 msgid ""
 "Focus on governance affairs, malevolent incidents, local strongmen, and "
 "political rivals creating obstacles."
@@ -3079,6 +3082,9 @@ msgstr "你得知 {subject_name} 被 {killer_name} 殺害。"
 
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "你得知 {subject_name} 與 {other_name}{bond_label}。"
+
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "你目睹 {predator_name} 在 {city_name} 吞食凡人。"
 
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "你得知 {subject_name} 發生了一件大事：{content}"

--- a/static/locales/zh-TW/modules/common.po
+++ b/static/locales/zh-TW/modules/common.po
@@ -253,5 +253,8 @@ msgstr "{surname}氏"
 msgid "Action on cooldown, {remain} month(s) remaining"
 msgstr "冷卻中，還需 {remain} 個月"
 
+msgid "Somewhere"
+msgstr "某處"
+
 msgid "Focus on governance affairs, malevolent incidents, local strongmen, and political rivals creating obstacles."
 msgstr "主題圍繞處理政務、遭遇邪祟、地方豪強、政敵掣肘展開。"

--- a/static/locales/zh-TW/modules/relation.po
+++ b/static/locales/zh-TW/modules/relation.po
@@ -183,6 +183,9 @@ msgstr "你得知 {subject_name} 被 {killer_name} 殺害。"
 msgid "You learned that {subject_name} and {other_name} {bond_label}."
 msgstr "你得知 {subject_name} 與 {other_name}{bond_label}。"
 
+msgid "You witnessed {predator_name} devouring mortals in {city_name}."
+msgstr "你目睹 {predator_name} 在 {city_name} 吞食凡人。"
+
 msgid "You learned that {subject_name} experienced a major event: {content}"
 msgstr "你得知 {subject_name} 發生了一件大事：{content}"
 

--- a/tests/test_public_predation_reactions.py
+++ b/tests/test_public_predation_reactions.py
@@ -1,0 +1,246 @@
+from src.classes.action.eat_mortals import EatMortals
+from src.classes.age import Age
+from src.classes.alignment import Alignment
+from src.classes.core.avatar import Avatar, Gender
+from src.classes.emotions import EmotionType
+from src.classes.environment.region import CityRegion
+from src.classes.environment.tile import Tile, TileType
+from src.classes.race import get_race
+from src.classes.root import Root
+from src.sim.simulator_engine.context import SimulationStepContext
+from src.sim.simulator_engine.finalizer import finalize_step
+from src.systems.cultivation import CultivationProgress, Realm
+from src.systems.time import Month, Year, create_month_stamp
+from src.utils.id_generator import get_avatar_id
+
+
+def _city_region() -> CityRegion:
+    return CityRegion(id=1001, name="TestCity", desc="测试城", cors=[(0, 0), (1, 0), (0, 1), (1, 1)])
+
+
+def _make_avatar(
+    world,
+    *,
+    name: str,
+    region: CityRegion,
+    race_id: str = "human",
+    alignment: Alignment = Alignment.RIGHTEOUS,
+    level: int = 1,
+    pos: tuple[int, int] = (0, 0),
+) -> Avatar:
+    avatar = Avatar(
+        world=world,
+        name=name,
+        id=get_avatar_id(),
+        birth_month_stamp=create_month_stamp(Year(1), Month.JANUARY),
+        age=Age(20, Realm.Qi_Refinement, innate_max_lifespan=80),
+        gender=Gender.MALE,
+        cultivation_progress=CultivationProgress(level=level),
+        pos_x=pos[0],
+        pos_y=pos[1],
+        root=Root.GOLD,
+        personas=[],
+        alignment=alignment,
+        race=get_race(race_id),
+    )
+    avatar.personas = []
+    avatar.technique = None
+    avatar.weapon = None
+    avatar.auxiliary = None
+    avatar.recalc_effects()
+    tile = Tile(pos[0], pos[1], TileType.CITY)
+    tile.region = region
+    avatar.tile = tile
+    world.avatar_manager.register_avatar(avatar)
+    return avatar
+
+
+async def _finish_public_predation(world, predator: Avatar):
+    event = (await EatMortals(predator, world).finish())[0]
+    ctx = SimulationStepContext(
+        world=world,
+        living_avatars=world.avatar_manager.get_living_avatars(),
+        events=[event],
+        month_stamp=world.month_stamp,
+    )
+    finalize_step(ctx)
+    return event
+
+
+async def test_public_predation_is_remembered_by_same_city_witness(base_world):
+    city = _city_region()
+    predator = _make_avatar(
+        base_world,
+        name="WolfYao",
+        region=city,
+        race_id="wolf",
+        alignment=Alignment.EVIL,
+        level=1,
+    )
+    witness = _make_avatar(
+        base_world,
+        name="RighteousWitness",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=30,
+        pos=(1, 0),
+    )
+
+    event = await _finish_public_predation(base_world, predator)
+
+    assert event.event_type == "public_predation"
+    memories = base_world.event_manager.get_major_events_by_avatar(witness.id)
+    assert len(memories) == 1
+    assert "WolfYao" in memories[0].content
+    assert "TestCity" in memories[0].content
+    assert witness.emotion is EmotionType.ANGRY
+
+
+async def test_righteous_strong_witness_queues_limited_response(base_world):
+    city = _city_region()
+    predator = _make_avatar(
+        base_world,
+        name="WolfYao",
+        region=city,
+        race_id="wolf",
+        alignment=Alignment.EVIL,
+        level=1,
+    )
+    witness = _make_avatar(
+        base_world,
+        name="Guardian",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=30,
+        pos=(1, 0),
+    )
+
+    await _finish_public_predation(base_world, predator)
+
+    assert [(plan.action_name, plan.params) for plan in witness.planned_actions] == [
+        ("MoveToAvatar", {"avatar_name": predator.name}),
+        ("Attack", {"avatar_name": predator.name}),
+    ]
+
+
+async def test_public_predation_limits_response_to_strongest_available_defender(base_world):
+    city = _city_region()
+    predator = _make_avatar(
+        base_world,
+        name="WolfYao",
+        region=city,
+        race_id="wolf",
+        alignment=Alignment.EVIL,
+        level=1,
+    )
+    first_guardian = _make_avatar(
+        base_world,
+        name="FirstGuardian",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=30,
+        pos=(1, 0),
+    )
+    strongest_guardian = _make_avatar(
+        base_world,
+        name="StrongestGuardian",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=50,
+        pos=(0, 1),
+    )
+    second_guardian = _make_avatar(
+        base_world,
+        name="SecondGuardian",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=40,
+        pos=(1, 1),
+    )
+
+    await _finish_public_predation(base_world, predator)
+
+    responders = [
+        avatar
+        for avatar in (first_guardian, strongest_guardian, second_guardian)
+        if avatar.planned_actions
+    ]
+    assert responders == [strongest_guardian]
+    assert [(plan.action_name, plan.params) for plan in strongest_guardian.planned_actions] == [
+        ("MoveToAvatar", {"avatar_name": predator.name}),
+        ("Attack", {"avatar_name": predator.name}),
+    ]
+
+
+async def test_public_predation_does_not_force_weak_or_busy_witness_response(base_world):
+    city = _city_region()
+    predator = _make_avatar(
+        base_world,
+        name="StrongWolfYao",
+        region=city,
+        race_id="wolf",
+        alignment=Alignment.EVIL,
+        level=60,
+    )
+    weak_witness = _make_avatar(
+        base_world,
+        name="WeakWitness",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=1,
+        pos=(1, 0),
+    )
+    busy_witness = _make_avatar(
+        base_world,
+        name="BusyWitness",
+        region=city,
+        alignment=Alignment.RIGHTEOUS,
+        level=90,
+        pos=(0, 1),
+    )
+    busy_witness.load_decide_result_chain([("Rest", {})], "already busy", "recover")
+
+    await _finish_public_predation(base_world, predator)
+
+    assert weak_witness.planned_actions == []
+    assert [(plan.action_name, plan.params) for plan in busy_witness.planned_actions] == [("Rest", {})]
+    assert weak_witness.emotion is EmotionType.FEARFUL
+    assert busy_witness.emotion is EmotionType.ANGRY
+
+
+async def test_public_predation_does_not_trigger_evil_or_distant_response(base_world):
+    city = _city_region()
+    distant_city = CityRegion(id=1002, name="FarCity", desc="远城", cors=[(8, 8)])
+    predator = _make_avatar(
+        base_world,
+        name="WolfYao",
+        region=city,
+        race_id="wolf",
+        alignment=Alignment.EVIL,
+        level=1,
+    )
+    evil_neighbor = _make_avatar(
+        base_world,
+        name="EvilNeighbor",
+        region=city,
+        alignment=Alignment.EVIL,
+        level=60,
+        pos=(1, 0),
+    )
+    distant_avatar = _make_avatar(
+        base_world,
+        name="DistantCultivator",
+        region=distant_city,
+        alignment=Alignment.RIGHTEOUS,
+        level=60,
+        pos=(8, 8),
+    )
+
+    await _finish_public_predation(base_world, predator)
+
+    evil_memories = base_world.event_manager.get_major_events_by_avatar(evil_neighbor.id)
+    assert len(evil_memories) == 1
+    assert "WolfYao" in evil_memories[0].content
+    assert evil_neighbor.planned_actions == []
+    assert distant_avatar.planned_actions == []
+    assert base_world.event_manager.get_major_events_by_avatar(distant_avatar.id) == []


### PR DESCRIPTION
## Summary

Make public `EatMortals` outcomes visible to nearby NPCs and allow a bounded world response.

## Motivation

After the yao race/predation work, `EatMortals` produced a major event for the predator, but nearby cultivators did not perceive or react to it. That made a public city incident feel isolated: the world state changed, but local NPC memory and behavior did not.

This PR turns public predation into a local observable event while keeping the reaction conservative.

## Design Note

I realize this touches simulation behavior, so I tried to keep it bounded and test-heavy. Still, once a yao cultivator can publicly devour mortals in a city, nearby NPCs quietly ignoring it feels like a missed story beat. Letting witnesses remember it, fear it, and occasionally have one capable righteous cultivator step in felt too fun and too fitting for the world to leave out.

## Changes

- Mark finished `EatMortals` events as `public_predation` with structured render params.
- Add a public event reaction service that:
  - adds local witness observations for same-city or observable avatars
  - records witness memory through the existing event observation pipeline
  - applies emotional response for non-evil witnesses
  - queues a response only for an idle, righteous, strong-enough witness
  - limits the action response to the strongest available responder
- Add observed-event rendering and locale entries for the new witness memory text.
- Wire public event reactions into the simulation finalizer before normal major-event propagation.

## Guardrails

- Story events are ignored.
- Dead avatars and the predator are skipped.
- Distant avatars do not receive the observation.
- Evil witnesses can remember the incident, but are not forced into a response.
- Weak witnesses become fearful instead of attacking.
- Busy witnesses keep their current plan/action.
- At most one responder is queued per public predation event.

## Test Plan

Multi-dimensional coverage added in `tests/test_public_predation_reactions.py`:

- Memory propagation: same-city witnesses receive a rendered major-event memory.
- Response planning: a strong righteous witness queues `MoveToAvatar -> Attack`.
- Overreaction guard: when several valid defenders are present, only the strongest one responds.
- Power guard: weak witnesses do not attack stronger predators.
- Plan safety: busy witnesses keep their existing planned action.
- Alignment guard: evil witnesses are not forced into a response.
- Distance guard: distant avatars neither remember nor respond.
- Locale integrity: new msgids are present across module and merged PO files.

Validated locally:

```bash
.venv/bin/python -m pytest tests/test_public_predation_reactions.py -q
# 5 passed

.venv/bin/python -m pytest tests/test_backend_locales.py tests/test_i18n_integrity.py -q
# 418 passed

.venv/bin/python -m pytest -q
# 1492 passed, 2 skipped
```

## Risk

Behavioral risk is limited to `public_predation` events. The response is intentionally capped and does not overwrite existing avatar work, so it should not create a broad chain reaction or disrupt normal action planning.

## Related Context

Builds on the newly added yao predation gameplay by letting public city incidents ripple into local NPC memory and a constrained defender response.
