### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/web/src/composables/useLlmConfigPanel.ts
+++ b/web/src/composables/useLlmConfigPanel.ts
@@ -106,8 +106,8 @@ export function useLlmConfigPanel(onConfigSaved: () => void) {
     {
       name: t('llm.presets.minimax'),
       base_url: 'https://api.minimax.io/v1',
-      model_name: 'MiniMax-M2.7',
-      fast_model_name: 'MiniMax-M2.5-highspeed',
+      model_name: 'MiniMax-M3',
+      fast_model_name: 'MiniMax-M2.7-highspeed',
       api_format: 'openai',
     },
     {


### PR DESCRIPTION
## Summary
将 MiniMax LLM preset 中的默认模型升级到最新的 M3 系列。

## Changes
- `model_name`: `MiniMax-M2.7` → `MiniMax-M3`（新一代旗舰模型）
- `fast_model_name`: `MiniMax-M2.5-highspeed` → `MiniMax-M2.7-highspeed`（当前 highspeed 版本）

## Why
MiniMax-M3 是 MiniMax 最新发布的旗舰模型，具备 512K 上下文窗口、128K 最大输出和图像输入支持，整体推理能力更强。`fast_model_name` 也同步升级到目前可用的 `M2.7-highspeed`，让默认/快速两档预设都是最新可用的模型。

## Testing
- 仅修改 `useLlmConfigPanel.ts` 中 MiniMax preset 两个字段，base_url / api_format 等其他配置保持不变
- 已通过相关单元测试：`web/src/__tests__/composables/useLlmAndAvatarDetailPanels.test.ts`（5/5 passed）
- TypeScript 类型检查通过（`npx tsc --noEmit`）