### PR TITLE
fix: 修复wls中docker容器中unhealthy问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - CWS_DISABLE_AUTO_SHUTDOWN=1
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8002/api/v1/query/runtime/status"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8002/api/v1/query/runtime/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/api/v1/query/runtime/status"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:80/api/v1/query/runtime/status"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/tests/test_docker_build_contract.py
+++ b/tests/test_docker_build_contract.py
@@ -229,6 +229,8 @@ def test_backend_compose_contract_exposes_port_and_healthcheck():
     assert '"8002:8002"' in backend_block
     assert "healthcheck:" in backend_block
     assert "test:" in backend_block
+    assert "http://127.0.0.1:8002/api/v1/query/runtime/status" in backend_block
+    assert "http://localhost:8002/api/v1/query/runtime/status" not in backend_block
     assert "interval:" in backend_block
     assert "timeout:" in backend_block
     assert "retries:" in backend_block
@@ -245,7 +247,8 @@ def test_frontend_compose_contract_depends_on_backend_and_exposes_port():
     assert '"8123:80"' in frontend_block
     assert "healthcheck:" in frontend_block
     assert "test:" in frontend_block
-    assert "http://localhost:80/api/v1/query/runtime/status" in frontend_block
+    assert "http://127.0.0.1:80/api/v1/query/runtime/status" in frontend_block
+    assert "http://localhost:80/api/v1/query/runtime/status" not in frontend_block
     assert "interval:" in frontend_block
     assert "timeout:" in frontend_block
     assert "retries:" in frontend_block

--- a/tests/test_docker_runtime_smoke.py
+++ b/tests/test_docker_runtime_smoke.py
@@ -98,6 +98,44 @@ def wait_until_frontend_proxy_ready(timeout_seconds: int = 120) -> None:
     )
 
 
+def get_compose_service_health(service_name: str) -> str | None:
+    service = run_compose("ps", "-q", service_name, timeout=60).stdout.strip()
+    if not service:
+        return None
+
+    result = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}",
+            service,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result.stdout.strip()
+
+
+def wait_until_compose_service_healthy(
+    service_name: str,
+    timeout_seconds: int = 120,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    last_health: str | None = None
+    while time.time() < deadline:
+        last_health = get_compose_service_health(service_name)
+        if last_health == "healthy":
+            return
+        time.sleep(2)
+    raise AssertionError(
+        f"Compose service {service_name!r} did not become healthy in time. "
+        f"Last health status: {last_health!r}"
+    )
+
+
 def wait_until_game_ready(timeout_seconds: int = 300) -> None:
     deadline = time.time() + timeout_seconds
     last_error: Exception | None = None
@@ -126,11 +164,33 @@ def wait_until_game_ready(timeout_seconds: int = 300) -> None:
 
 @pytest.mark.docker
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not found in PATH")
+def test_docker_compose_services_become_healthy():
+    try:
+        run_compose("up", "-d", timeout=600)
+        wait_until_backend_ready()
+        wait_until_frontend_proxy_ready()
+        wait_until_compose_service_healthy("backend")
+        wait_until_compose_service_healthy("frontend")
+    finally:
+        subprocess.run(
+            ["docker", "compose", "down"],
+            cwd=get_project_root(),
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not found in PATH")
 def test_docker_compose_persists_settings_after_recreate():
     try:
         run_compose("up", "-d", "--build", timeout=900)
         wait_until_backend_ready()
         wait_until_frontend_proxy_ready()
+        wait_until_compose_service_healthy("backend")
+        wait_until_compose_service_healthy("frontend")
 
         updated = http_json(
             "http://localhost:8002/api/settings",
@@ -190,6 +250,9 @@ def test_docker_compose_persists_settings_after_recreate():
         run_compose("down", timeout=180)
         run_compose("up", "-d", timeout=600)
         wait_until_backend_ready()
+        wait_until_frontend_proxy_ready()
+        wait_until_compose_service_healthy("backend")
+        wait_until_compose_service_healthy("frontend")
 
         after_recreate = http_json("http://localhost:8002/api/settings")
         assert after_recreate["simulation"]["auto_save_enabled"] is True


### PR DESCRIPTION
## Summary

按照现有的docker中的地址构建会导致 健康检查后的容器中的前端显示为unhealthy，实际上前后端的容器都是健康启动的。
<img width="3342" height="1620" alt="94a821cf59d292711dcef9fc4aec60a6" src="https://github.com/user-attachments/assets/543f14a5-a9e8-49fc-8b1d-d073d0139537" />

前端相应的健康检查位于 `docker-compose.yml`：

```yaml
frontend:
  healthcheck:
    test:
      [
        "CMD",
        "wget",
        "--no-verbose",
        "--tries=1",
        "--spider",
        "http://localhost:80/api/v1/query/runtime/status"
      ]
    interval: 30s
    timeout: 10s
    retries: 3
```

Nginx 监听配置位于 `deploy/nginx.conf`：

```nginx
server {
    listen 80;
    server_name localhost;
}
```

`listen 80;` 在当前容器中只保证 IPv4 监听，并不等同于同时监听 `[::]:80`。

浏览器可以正常访问，但是docker全显示unhealthy。其原因为：
1. 健康检查通过 `localhost` 访问 Nginx；
2. 容器内的 `localhost` 优先解析为 IPv6 回环地址 `::1`；
3. Nginx 当前只监听 IPv4 的 `80` 端口；
4. 当前镜像中的 `wget` 在连接 `::1:80` 被拒绝后，没有成功回退至 IPv4；
5. Docker 因此误判前端容器不健康。

而浏览器这边走的是：

```text
浏览器或宿主机请求
  -> 127.0.0.1:8123
  -> Docker IPv4 端口映射
  -> 前端容器 IPv4:80
  -> Nginx
  -> backend:8002
  -> 成功
```

所以本质是健康检查目标地址与服务监听协议族不一致，直接修改健康检查中的地址即可。
将前端健康检查中的：

```text
http://localhost:80/api/v1/query/runtime/status
```

修改为：

```text
http://127.0.0.1:80/api/v1/query/runtime/status
```
<img width="3470" height="1959" alt="5877246bcc2861834a3524b7c9e9ad43" src="https://github.com/user-attachments/assets/76e9d054-92c7-4991-8e6d-42f203325f87" />

## Test Plan

已通过原本测试，并新增新的健康检查测试
